### PR TITLE
🐛 Fix prod WebAuthn for Tauri mobile apps

### DIFF
--- a/.github/workflows/tauri-mobile-release.yml
+++ b/.github/workflows/tauri-mobile-release.yml
@@ -23,6 +23,7 @@ concurrency:
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 env:
   CI: true
@@ -376,12 +377,21 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
 
+      - name: "📌 Create version bump PR"
+        if: github.ref == 'refs/heads/main'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "⬆️ v${{ inputs.version }}"
+          branch: chore/mobile-v${{ inputs.version }}
+          title: "⬆️ v${{ inputs.version }}"
+          body: "Auto-generated version bump from mobile release workflow."
+          delete-branch: true
+
       - name: "📌 Commit & push"
+        if: github.ref != 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "⬆️ v$VERSION" || echo "No changes to commit"
+          git commit -m "⬆️ v${{ inputs.version }}" || echo "No changes to commit"
           git push
-        env:
-          VERSION: ${{ inputs.version }}

--- a/apps/wallet/src-tauri/gen/apple/app_iOS/app_iOS.entitlements
+++ b/apps/wallet/src-tauri/gen/apple/app_iOS/app_iOS.entitlements
@@ -6,8 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>webcredentials:frak.id</string>
 		<string>webcredentials:wallet-dev.frak.id</string>
-		<string>webcredentials:wallet.frak.id</string>
 		<string>applinks:wallet.frak.id</string>
 		<string>applinks:wallet-dev.frak.id</string>
 	</array>


### PR DESCRIPTION
## Summary

- Add `webcredentials:frak.id` to iOS entitlements (required for prod RP ID `frak.id`)
- Remove unused `webcredentials:wallet.frak.id` entry
- Fix mobile release workflow version bump blocked by branch protection

## Context

Production Tauri apps use RP ID `frak.id` for WebAuthn, but iOS entitlements only listed `wallet-dev.frak.id` and `wallet.frak.id` — neither matches the prod RP ID. iOS couldn't verify the app-domain association, breaking passkeys.

Companion change: `.well-known` files added to `frak.id` landing site (static-web repo, already deployed).