### PR TITLE
✨ Shopify dashboard: newsletter share link + optional setup card

### DIFF
--- a/apps/business/src/module/merchant/component/MerchantDetails/NewsletterShareLink.module.css
+++ b/apps/business/src/module/merchant/component/MerchantDetails/NewsletterShareLink.module.css
@@ -1,0 +1,5 @@
+.description {
+    margin: 0 0 16px;
+    font-size: 14px;
+    color: var(--text-secondary, #666);
+}

--- a/apps/business/src/module/merchant/component/MerchantDetails/NewsletterShareLink.tsx
+++ b/apps/business/src/module/merchant/component/MerchantDetails/NewsletterShareLink.tsx
@@ -1,0 +1,30 @@
+import { TextWithCopy } from "@frak-labs/ui/component/TextWithCopy";
+import { Panel } from "@/module/common/component/Panel";
+import { useMerchant } from "@/module/merchant/hook/useMerchant";
+import styles from "./NewsletterShareLink.module.css";
+
+function buildShareUrl(domain: string): string {
+    return `https://${domain}/?frakAction=share`;
+}
+
+export function NewsletterShareLink({ merchantId }: { merchantId: string }) {
+    const { data: merchant } = useMerchant({ merchantId });
+
+    if (!merchant?.domain) return null;
+
+    const shareUrl = buildShareUrl(merchant.domain);
+
+    return (
+        <Panel title={"Newsletter sharing link"} withBadge={false}>
+            <p className={styles.description}>
+                Paste this link into your newsletter or any marketing email.
+                When a customer clicks it, your storefront opens with the Frak
+                sharing modal, pre-filled with your current campaign rewards, so
+                they can share and earn in one tap.
+            </p>
+            <TextWithCopy text={shareUrl} style={{ width: "100%" }}>
+                <pre>{shareUrl}</pre>
+            </TextWithCopy>
+        </Panel>
+    );
+}

--- a/apps/business/src/module/merchant/component/MerchantDetails/index.tsx
+++ b/apps/business/src/module/merchant/component/MerchantDetails/index.tsx
@@ -26,6 +26,7 @@ import { useMerchant } from "@/module/merchant/hook/useMerchant";
 import { useMerchantUpdate } from "@/module/merchant/hook/useMerchantUpdate";
 import { AllowedDomains } from "./AllowedDomains";
 import { ExplorerSettings } from "./ExplorerSettings";
+import { NewsletterShareLink } from "./NewsletterShareLink";
 import { PurchasseTrackerSetup } from "./PurchaseTracker";
 
 type FormMerchant = {
@@ -199,6 +200,7 @@ export function MerchantDetails({ merchantId }: { merchantId: string }) {
                 merchantId={merchantId}
                 allowedDomains={merchant?.allowedDomains ?? []}
             />
+            <NewsletterShareLink merchantId={merchantId} />
             <ExplorerSettings merchantId={merchantId} />
             <PurchasseTrackerSetup merchantId={merchantId} />
         </FormLayout>

--- a/apps/shopify/app/components/OptionalSetup/index.tsx
+++ b/apps/shopify/app/components/OptionalSetup/index.tsx
@@ -1,0 +1,112 @@
+import { useVisibilityChange } from "app/hooks/useVisibilityChange";
+import type { loader as appLoader } from "app/routes/app";
+import type { OnboardingStepData } from "app/utils/onboarding";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useRouteLoaderData } from "react-router";
+import screenShareButton from "../../assets/share-button.png";
+import { useRefreshData } from "../../hooks/useRefreshData";
+import { ExternalButton } from "../ui/ExternalLink";
+
+/**
+ * Surfaces the two non-critical onboarding items (share button + banner)
+ * as a "finish your setup" card on the index page.
+ *
+ * Renders once the critical onboarding (steps 1-5) is done — the
+ * merchant can already ship live, but these UI bits unlock storefront
+ * discovery (share button) and referee conversion (banner). The card
+ * disappears entirely once both are activated.
+ *
+ * Tab visibility triggers a refresh so detection picks up changes made
+ * in the Shopify theme editor without a manual reload.
+ */
+export function OptionalSetup({
+    onboardingData,
+}: {
+    onboardingData: OnboardingStepData;
+}) {
+    const { t } = useTranslation();
+    const refresh = useRefreshData();
+
+    useVisibilityChange(
+        useCallback(() => {
+            refresh();
+        }, [refresh])
+    );
+
+    const showShareButton =
+        !onboardingData.isThemeHasFrakButton &&
+        Boolean(onboardingData.firstProduct);
+    const showBanner = !onboardingData.isThemeHasFrakBanner;
+
+    if (!showShareButton && !showBanner) return null;
+
+    return (
+        <s-section>
+            <s-stack gap="base">
+                <s-heading>{t("optionalSetup.title")}</s-heading>
+                <s-text>{t("optionalSetup.description")}</s-text>
+                <s-stack gap="base">
+                    {showShareButton && (
+                        <ShareButtonCard
+                            productHandle={onboardingData.firstProduct?.handle}
+                        />
+                    )}
+                    {showBanner && <BannerCard />}
+                </s-stack>
+            </s-stack>
+        </s-section>
+    );
+}
+
+function useThemeEditorUrl(): string {
+    const rootData = useRouteLoaderData<typeof appLoader>("routes/app");
+    return `https://${rootData?.shop?.myshopifyDomain}/admin/themes/current/editor`;
+}
+
+function ShareButtonCard({ productHandle }: { productHandle?: string }) {
+    const { t } = useTranslation();
+    const editorUrl = useThemeEditorUrl();
+    const href = productHandle
+        ? `${editorUrl}?previewPath=/products/${productHandle}`
+        : null;
+
+    return (
+        <s-box background="subdued" padding="base">
+            <s-stack gap="base">
+                <s-heading>{t("optionalSetup.shareButton.title")}</s-heading>
+                <s-text>{t("optionalSetup.shareButton.description")}</s-text>
+                <img
+                    src={screenShareButton}
+                    alt=""
+                    style={{ maxWidth: "320px" }}
+                />
+                {href && (
+                    <ExternalButton variant="primary" href={href}>
+                        {t("optionalSetup.shareButton.cta")}
+                    </ExternalButton>
+                )}
+            </s-stack>
+        </s-box>
+    );
+}
+
+function BannerCard() {
+    const { t } = useTranslation();
+    const editorUrl = useThemeEditorUrl();
+
+    return (
+        <s-box background="subdued" padding="base">
+            <s-stack gap="base">
+                <s-heading>{t("optionalSetup.banner.title")}</s-heading>
+                <s-text>{t("optionalSetup.banner.description")}</s-text>
+                <ExternalButton
+                    variant="primary"
+                    href={`${editorUrl}?context=apps`}
+                >
+                    {t("optionalSetup.banner.cta")}
+                </ExternalButton>
+            </s-stack>
+        </s-box>
+    );
+}

--- a/apps/shopify/app/components/Sharing/index.tsx
+++ b/apps/shopify/app/components/Sharing/index.tsx
@@ -1,0 +1,70 @@
+import type { loader as appLoader } from "app/routes/app";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useRouteLoaderData } from "react-router";
+
+/**
+ * Build the canonical share URL for a given storefront host.
+ *
+ * Mirrors `buildShareUrl` from `services.server/metafields.ts` — kept
+ * client-side so the merchant UI can render the link without an extra
+ * loader round-trip. The SDK loader treats `?frakAction=share` as a
+ * directive to auto-open the sharing modal (see `handleActionQueryParam`
+ * in `sdk/components/src/bootstrap/initFrakSdk.ts`).
+ */
+function buildShareUrl(domain: string): string {
+    return `https://${domain}/?frakAction=share`;
+}
+
+/**
+ * Card surfacing a copy-paste sharing link merchants can drop into
+ * newsletters / emails. Clicking the link auto-opens the storefront
+ * sharing modal pre-filled with the merchant's active reward config.
+ */
+export function NewsletterShareLink() {
+    const { t } = useTranslation();
+    const rootData = useRouteLoaderData<typeof appLoader>("routes/app");
+    const domain = rootData?.shop.domain;
+
+    const shareUrl = useMemo(
+        () => (domain ? buildShareUrl(domain) : null),
+        [domain]
+    );
+
+    const handleCopy = useCallback(async () => {
+        if (!shareUrl) return;
+        try {
+            await navigator.clipboard.writeText(shareUrl);
+            shopify.toast.show(t("status.newsletterShare.copied"));
+        } catch (error) {
+            console.error("[newsletterShare] copy failed:", error);
+            shopify.toast.show(t("status.newsletterShare.copyError"), {
+                isError: true,
+            });
+        }
+    }, [shareUrl, t]);
+
+    if (!shareUrl) return null;
+
+    return (
+        <s-section>
+            <s-stack gap="base">
+                <s-heading>{t("status.newsletterShare.title")}</s-heading>
+                <s-text>{t("status.newsletterShare.description")}</s-text>
+                <s-box background="subdued" padding="base">
+                    <s-stack
+                        direction="inline"
+                        gap="base"
+                        alignItems="center"
+                        justifyContent="space-between"
+                    >
+                        <s-text>{shareUrl}</s-text>
+                        <s-button variant="primary" onClick={handleCopy}>
+                            {t("status.newsletterShare.copy")}
+                        </s-button>
+                    </s-stack>
+                </s-box>
+            </s-stack>
+        </s-section>
+    );
+}

--- a/apps/shopify/app/components/Stepper/index.tsx
+++ b/apps/shopify/app/components/Stepper/index.tsx
@@ -70,18 +70,19 @@ function StepsIntroduction({
 }) {
     const navigate = useNavigate();
     const { t } = useTranslation();
-    const { completedSteps } = validateCompleteOnboarding(onboardingData);
+    const { completedSteps, hasMissedCriticalSteps } =
+        validateCompleteOnboarding(onboardingData);
     const completedStep = completedSteps.length;
     const progress = (completedStep / MAX_STEP) * 100;
 
     useEffect(() => {
-        if (progress === 100 && redirectToApp) {
+        if (!hasMissedCriticalSteps && redirectToApp) {
             // Small delay to ensure the progress bar is updated
             setTimeout(() => {
                 navigate("/app");
             }, 1000);
         }
-    }, [progress, navigate, redirectToApp]);
+    }, [hasMissedCriticalSteps, navigate, redirectToApp]);
 
     return (
         <s-stack gap="small">

--- a/apps/shopify/app/i18n/locales/en/translation.json
+++ b/apps/shopify/app/i18n/locales/en/translation.json
@@ -141,6 +141,13 @@
             "button": "Register your shop in the Frak ecosystem",
             "close": "Close"
         },
+        "newsletterShare": {
+            "title": "Newsletter sharing link",
+            "description": "Paste this link into your newsletter or any marketing email. When a customer clicks it, your storefront opens with the Frak sharing modal — pre-filled with your current campaign rewards — so they can share and earn in one tap.",
+            "copy": "Copy link",
+            "copied": "Sharing link copied to clipboard",
+            "copyError": "Could not copy link. Please copy it manually."
+        },
 
         "campaign": {
             "title": "Campaigns",

--- a/apps/shopify/app/i18n/locales/en/translation.json
+++ b/apps/shopify/app/i18n/locales/en/translation.json
@@ -58,6 +58,20 @@
             "link": "Add the Frak Banner to your theme"
         }
     },
+    "optionalSetup": {
+        "title": "Finish your setup with end-user UI components",
+        "description": "Your store is live and can already distribute rewards. These two optional storefront components unlock organic sharing and referee conversion. Add them when you are ready.",
+        "shareButton": {
+            "title": "Add the share button to your product pages",
+            "description": "Adds a one-click share button on every product page. Visitors share the page with their network, and the link automatically carries their referral identity so they earn a reward when someone they invited buys.",
+            "cta": "Open the theme editor"
+        },
+        "banner": {
+            "title": "Add the referee banner to your theme",
+            "description": "Shown only to visitors who land on your store through a referral link. The banner confirms they were invited, explains the reward they will earn for buying, and turns a cold visit into a primed conversion.",
+            "cta": "Open the theme editor"
+        }
+    },
     "pixel": {
         "title": "Application pixel",
         "connected": "Your pixel is connected to your store.",
@@ -143,7 +157,7 @@
         },
         "newsletterShare": {
             "title": "Newsletter sharing link",
-            "description": "Paste this link into your newsletter or any marketing email. When a customer clicks it, your storefront opens with the Frak sharing modal — pre-filled with your current campaign rewards — so they can share and earn in one tap.",
+            "description": "Paste this link into your newsletter or any marketing email. When a customer clicks it, your storefront opens with the Frak sharing modal, pre-filled with your current campaign rewards, so they can share and earn in one tap.",
             "copy": "Copy link",
             "copied": "Sharing link copied to clipboard",
             "copyError": "Could not copy link. Please copy it manually."

--- a/apps/shopify/app/i18n/locales/fr/translation.json
+++ b/apps/shopify/app/i18n/locales/fr/translation.json
@@ -142,6 +142,13 @@
             "button": "Enregistrer votre boutique dans l'écosystème Frak",
             "close": "Fermer"
         },
+        "newsletterShare": {
+            "title": "Lien de partage pour newsletter",
+            "description": "Collez ce lien dans votre newsletter ou tout autre e-mail marketing. Lorsqu'un client cliquera dessus, votre boutique s'ouvrira avec la modale de partage Frak — pré-remplie avec les récompenses de vos campagnes en cours — pour qu'il puisse partager et gagner en un clic.",
+            "copy": "Copier le lien",
+            "copied": "Lien de partage copié dans le presse-papiers",
+            "copyError": "Impossible de copier le lien. Merci de le copier manuellement."
+        },
 
         "campaign": {
             "title": "Campagnes",

--- a/apps/shopify/app/i18n/locales/fr/translation.json
+++ b/apps/shopify/app/i18n/locales/fr/translation.json
@@ -58,6 +58,20 @@
             "link": "Ajouter la bannière Frak à votre thème"
         }
     },
+    "optionalSetup": {
+        "title": "Finalisez votre configuration avec les composants UI pour vos utilisateurs",
+        "description": "Votre boutique est en ligne et peut déjà distribuer des récompenses. Ces deux composants optionnels améliorent le partage organique et la conversion des filleuls. Ajoutez-les quand vous êtes prêt.",
+        "shareButton": {
+            "title": "Ajoutez le bouton de partage à vos pages produit",
+            "description": "Ajoute un bouton de partage en un clic sur chaque page produit. Vos visiteurs partagent la page avec leur réseau, et le lien embarque automatiquement leur identité de parrain pour qu'ils gagnent une récompense lorsqu'un filleul achète.",
+            "cta": "Ouvrir l'éditeur de thème"
+        },
+        "banner": {
+            "title": "Ajoutez la bannière filleul à votre thème",
+            "description": "Affichée uniquement aux visiteurs qui arrivent sur votre boutique via un lien de parrainage. La bannière leur confirme qu'ils ont été invités, explique la récompense qu'ils obtiendront en achetant, et transforme une visite froide en conversion qualifiée.",
+            "cta": "Ouvrir l'éditeur de thème"
+        }
+    },
     "pixel": {
         "title": "Pixel d'application",
         "connected": "Votre pixel est connecté à votre boutique.",
@@ -144,7 +158,7 @@
         },
         "newsletterShare": {
             "title": "Lien de partage pour newsletter",
-            "description": "Collez ce lien dans votre newsletter ou tout autre e-mail marketing. Lorsqu'un client cliquera dessus, votre boutique s'ouvrira avec la modale de partage Frak — pré-remplie avec les récompenses de vos campagnes en cours — pour qu'il puisse partager et gagner en un clic.",
+            "description": "Collez ce lien dans votre newsletter ou tout autre e-mail marketing. Lorsqu'un client cliquera dessus, votre boutique s'ouvrira avec la modale de partage Frak, pré-remplie avec les récompenses de vos campagnes en cours, pour qu'il puisse partager et gagner en un clic.",
             "copy": "Copier le lien",
             "copied": "Lien de partage copié dans le presse-papiers",
             "copyError": "Impossible de copier le lien. Merci de le copier manuellement."

--- a/apps/shopify/app/routes/app._index.tsx
+++ b/apps/shopify/app/routes/app._index.tsx
@@ -1,3 +1,4 @@
+import { NewsletterShareLink } from "app/components/Sharing";
 import { Stepper } from "app/components/Stepper";
 import { ExternalButton } from "app/components/ui/ExternalLink";
 import { PageHeading } from "app/components/ui/PageHeading";
@@ -135,6 +136,7 @@ function OnBoardingComplete({
 }) {
     return (
         <s-stack gap="large">
+            <NewsletterShareLink />
             <CampaignStatus campaigns={campaigns} bankStatus={bankStatus} />
             <BankingStatus bankStatus={bankStatus} />
         </s-stack>

--- a/apps/shopify/app/routes/app._index.tsx
+++ b/apps/shopify/app/routes/app._index.tsx
@@ -1,3 +1,4 @@
+import { OptionalSetup } from "app/components/OptionalSetup";
 import { NewsletterShareLink } from "app/components/Sharing";
 import { Stepper } from "app/components/Stepper";
 import { ExternalButton } from "app/components/ui/ExternalLink";
@@ -103,7 +104,7 @@ function ThemeSupported({
     const { campaigns, bankStatus } = useLoaderData<typeof loader>();
     const validationResult = validateCompleteOnboarding(onboardingData);
 
-    if (!validationResult.isComplete) {
+    if (validationResult.hasMissedCriticalSteps) {
         return <Stepper redirectToApp={false} />;
     }
 
@@ -122,7 +123,11 @@ function ThemeSupported({
 
     return (
         <s-stack gap="large">
-            <OnBoardingComplete campaigns={campaigns} bankStatus={bankStatus} />
+            <OnBoardingComplete
+                campaigns={campaigns}
+                bankStatus={bankStatus}
+                onboardingData={onboardingData}
+            />
         </s-stack>
     );
 }
@@ -130,15 +135,18 @@ function ThemeSupported({
 function OnBoardingComplete({
     campaigns,
     bankStatus,
+    onboardingData,
 }: {
     campaigns: CampaignResponse[];
     bankStatus: BankStatus;
+    onboardingData: OnboardingStepData;
 }) {
     return (
         <s-stack gap="large">
             <NewsletterShareLink />
             <CampaignStatus campaigns={campaigns} bankStatus={bankStatus} />
             <BankingStatus bankStatus={bankStatus} />
+            <OptionalSetup onboardingData={onboardingData} />
         </s-stack>
     );
 }

--- a/apps/shopify/app/routes/app.campaigns.tsx
+++ b/apps/shopify/app/routes/app.campaigns.tsx
@@ -1,4 +1,5 @@
 import { CampaignStatus } from "app/components/Campaign";
+import { NewsletterShareLink } from "app/components/Sharing";
 import { ExternalButton } from "app/components/ui/ExternalLink";
 import { PageHeading } from "app/components/ui/PageHeading";
 import type { loader as appLoader } from "app/routes/app";
@@ -212,7 +213,13 @@ export default function CampaignsPage() {
                 </div>
             </div>
             {campaigns && bankStatus ? (
-                <CampaignStatus campaigns={campaigns} bankStatus={bankStatus} />
+                <s-stack gap="large">
+                    <CampaignStatus
+                        campaigns={campaigns}
+                        bankStatus={bankStatus}
+                    />
+                    <NewsletterShareLink />
+                </s-stack>
             ) : (
                 // TODO: Link to the settings / setup instructions
                 <p>Nope</p>


### PR DESCRIPTION
## Summary

Adds a "finish your setup" panel and a sharing-link copy block to the Shopify merchant dashboard so non-critical onboarding (share button + banner) and quick newsletter sharing are surfaced after the merchant goes live.

## Changes

- `OptionalSetup` component (`apps/shopify/app/components/OptionalSetup/index.tsx`) — renders share-button + banner cards once critical onboarding is complete, auto-refreshes on tab focus so theme-editor edits are picked up
- `Sharing` component (`apps/shopify/app/components/Sharing/index.tsx`) — copyable newsletter share link in the dashboard
- `NewsletterShareLink` card on the merchant details view
- New `optionalSetup.*` and sharing translation strings (en/fr)
- `Stepper` + `app._index` + `app.campaigns` wired to the new optional flow

## Commits

- `baadade8f` ✨ Add newsletter sharing link to shopify dashboard
- `f0d44c8f8` ✨ Non critical onboarding step released on the index page
- `1f9d5fec4` ✨ Add sharing link copy to dashboard
