### PR TITLE
🌐 Shopify i18n + frak_i18n metaobject migration

### DIFF
--- a/apps/shopify/app/routes/app.settings.general.tsx
+++ b/apps/shopify/app/routes/app.settings.general.tsx
@@ -1,14 +1,30 @@
 import { ConnectedShopInfo } from "app/components/ConnectedShopInfo";
 import { Stepper } from "app/components/Stepper";
 import { resolveMerchantInfo } from "app/services.server/merchant";
+import {
+    ensureFrakI18nMetaobject,
+    type FrakI18nSyncResult,
+} from "app/services.server/metafields";
 import { authenticate } from "app/shopify.server";
-import type { LoaderFunctionArgs } from "react-router";
-import { data, useLoaderData } from "react-router";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { data, useFetcher, useLoaderData } from "react-router";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
     const context = await authenticate.admin(request);
     const merchantInfo = await resolveMerchantInfo(context);
     return data({ merchantInfo });
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+    const context = await authenticate.admin(request);
+    const formData = await request.formData();
+    if (formData.get("intent") === "resync-i18n") {
+        const syncResult = await ensureFrakI18nMetaobject(context, {
+            bypassCache: true,
+        });
+        return data({ syncResult });
+    }
+    return data({});
 };
 
 export default function SettingsGeneralPage() {
@@ -18,6 +34,66 @@ export default function SettingsGeneralPage() {
         <s-stack gap="large">
             {merchantInfo && <ConnectedShopInfo merchantInfo={merchantInfo} />}
             <Stepper redirectToApp={false} />
+            <I18nSyncDebugCard />
+        </s-stack>
+    );
+}
+
+function I18nSyncDebugCard() {
+    const fetcher = useFetcher<{ syncResult?: FrakI18nSyncResult }>();
+    const isLoading = fetcher.state !== "idle";
+    const result = fetcher.data?.syncResult;
+    return (
+        <s-section heading="Translations debug">
+            <s-stack gap="base">
+                <s-text>
+                    Force re-sync the Frak Translations metaobject (creates the
+                    entry if missing and registers bundled French translations).
+                    Surfaces the exact Shopify error if something fails.
+                </s-text>
+                <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="resync-i18n" />
+                    <s-button
+                        type="submit"
+                        disabled={isLoading}
+                        variant="secondary"
+                    >
+                        {isLoading ? "Re-syncing…" : "Force re-sync"}
+                    </s-button>
+                </fetcher.Form>
+                {result && <I18nSyncResultDisplay result={result} />}
+            </s-stack>
+        </s-section>
+    );
+}
+
+function I18nSyncResultDisplay({ result }: { result: FrakI18nSyncResult }) {
+    const ok = result.errors.length === 0;
+    return (
+        <s-stack gap="small">
+            <s-text>
+                <strong>Definition:</strong>{" "}
+                {result.definitionOk ? "OK" : "FAILED"}
+            </s-text>
+            <s-text>
+                <strong>Entry ID:</strong> {result.entryId ?? "(none)"}
+            </s-text>
+            <s-text>
+                <strong>FR translations registered:</strong>{" "}
+                {result.frTranslationsRegistered}
+            </s-text>
+            {ok ? (
+                <s-text>All steps succeeded.</s-text>
+            ) : (
+                <s-stack gap="small">
+                    <s-text>
+                        <strong>Errors:</strong>
+                    </s-text>
+                    {result.errors.map((err) => (
+                        <s-text key={err}>{err}</s-text>
+                    ))}
+                </s-stack>
+            )}
         </s-stack>
     );
 }

--- a/apps/shopify/app/routes/app.settings.general.tsx
+++ b/apps/shopify/app/routes/app.settings.general.tsx
@@ -1,30 +1,14 @@
 import { ConnectedShopInfo } from "app/components/ConnectedShopInfo";
 import { Stepper } from "app/components/Stepper";
 import { resolveMerchantInfo } from "app/services.server/merchant";
-import {
-    ensureFrakI18nMetaobject,
-    type FrakI18nSyncResult,
-} from "app/services.server/metafields";
 import { authenticate } from "app/shopify.server";
-import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
-import { data, useFetcher, useLoaderData } from "react-router";
+import type { LoaderFunctionArgs } from "react-router";
+import { data, useLoaderData } from "react-router";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
     const context = await authenticate.admin(request);
     const merchantInfo = await resolveMerchantInfo(context);
     return data({ merchantInfo });
-};
-
-export const action = async ({ request }: ActionFunctionArgs) => {
-    const context = await authenticate.admin(request);
-    const formData = await request.formData();
-    if (formData.get("intent") === "resync-i18n") {
-        const syncResult = await ensureFrakI18nMetaobject(context, {
-            bypassCache: true,
-        });
-        return data({ syncResult });
-    }
-    return data({});
 };
 
 export default function SettingsGeneralPage() {
@@ -34,66 +18,6 @@ export default function SettingsGeneralPage() {
         <s-stack gap="large">
             {merchantInfo && <ConnectedShopInfo merchantInfo={merchantInfo} />}
             <Stepper redirectToApp={false} />
-            <I18nSyncDebugCard />
-        </s-stack>
-    );
-}
-
-function I18nSyncDebugCard() {
-    const fetcher = useFetcher<{ syncResult?: FrakI18nSyncResult }>();
-    const isLoading = fetcher.state !== "idle";
-    const result = fetcher.data?.syncResult;
-    return (
-        <s-section heading="Translations debug">
-            <s-stack gap="base">
-                <s-text>
-                    Force re-sync the Frak Translations metaobject (creates the
-                    entry if missing and registers bundled French translations).
-                    Surfaces the exact Shopify error if something fails.
-                </s-text>
-                <fetcher.Form method="post">
-                    <input type="hidden" name="intent" value="resync-i18n" />
-                    <s-button
-                        type="submit"
-                        disabled={isLoading}
-                        variant="secondary"
-                    >
-                        {isLoading ? "Re-syncing…" : "Force re-sync"}
-                    </s-button>
-                </fetcher.Form>
-                {result && <I18nSyncResultDisplay result={result} />}
-            </s-stack>
-        </s-section>
-    );
-}
-
-function I18nSyncResultDisplay({ result }: { result: FrakI18nSyncResult }) {
-    const ok = result.errors.length === 0;
-    return (
-        <s-stack gap="small">
-            <s-text>
-                <strong>Definition:</strong>{" "}
-                {result.definitionOk ? "OK" : "FAILED"}
-            </s-text>
-            <s-text>
-                <strong>Entry ID:</strong> {result.entryId ?? "(none)"}
-            </s-text>
-            <s-text>
-                <strong>FR translations registered:</strong>{" "}
-                {result.frTranslationsRegistered}
-            </s-text>
-            {ok ? (
-                <s-text>All steps succeeded.</s-text>
-            ) : (
-                <s-stack gap="small">
-                    <s-text>
-                        <strong>Errors:</strong>
-                    </s-text>
-                    {result.errors.map((err) => (
-                        <s-text key={err}>{err}</s-text>
-                    ))}
-                </s-stack>
-            )}
         </s-stack>
     );
 }

--- a/apps/shopify/app/routes/app.tsx
+++ b/apps/shopify/app/routes/app.tsx
@@ -9,10 +9,7 @@ import {
     ensureWalletUrlMetafield,
     resolveMerchantId,
 } from "app/services.server/merchant";
-import {
-    cleanupLegacyFrakI18nMetafields,
-    ensureFrakI18nMetaobject,
-} from "app/services.server/metafields";
+import { ensureFrakI18nMetaobject } from "app/services.server/metafields";
 import { shopInfo } from "app/services.server/shop";
 import { doesThemeSupportBlock } from "app/services.server/theme";
 import { shouldShowOutletSkeleton } from "app/utils/navigationLoading";
@@ -51,11 +48,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // a ready-to-use share CTA into their email templates without
     // hard-coding the storefront host.
     ensureKlaviyoShareMetafields(context).catch(() => {});
-    // Fire-and-forget: ensure the $app:frak_i18n metaobject singleton
-    // entry exists with EN seeds + bundled FR translations, then drop
-    // the legacy SHOP-scoped translatable metafields (one-time migration).
+    // Fire-and-forget: ensure the frak_i18n metaobject singleton entry
+    // exists with EN seeds + bundled FR translations.
     ensureFrakI18nMetaobject(context).catch(() => {});
-    cleanupLegacyFrakI18nMetafields(context).catch(() => {});
 
     return {
         apiKey: process.env.SHOPIFY_API_KEY || "",

--- a/apps/shopify/app/routes/app.tsx
+++ b/apps/shopify/app/routes/app.tsx
@@ -9,7 +9,10 @@ import {
     ensureWalletUrlMetafield,
     resolveMerchantId,
 } from "app/services.server/merchant";
-import { ensureFrakI18nMetafieldDefinitions } from "app/services.server/metafields";
+import {
+    cleanupLegacyFrakI18nMetafields,
+    ensureFrakI18nMetaobject,
+} from "app/services.server/metafields";
 import { shopInfo } from "app/services.server/shop";
 import { doesThemeSupportBlock } from "app/services.server/theme";
 import { shouldShowOutletSkeleton } from "app/utils/navigationLoading";
@@ -48,10 +51,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // a ready-to-use share CTA into their email templates without
     // hard-coding the storefront host.
     ensureKlaviyoShareMetafields(context).catch(() => {});
-    // Fire-and-forget: register translatable text metafield definitions so
-    // Translate & Adapt can surface per-locale editors for banner / share
-    // button / post-purchase strings.
-    ensureFrakI18nMetafieldDefinitions(context).catch(() => {});
+    // Fire-and-forget: ensure the $app:frak_i18n metaobject singleton
+    // entry exists with EN seeds + bundled FR translations, then drop
+    // the legacy SHOP-scoped translatable metafields (one-time migration).
+    ensureFrakI18nMetaobject(context).catch(() => {});
+    cleanupLegacyFrakI18nMetafields(context).catch(() => {});
 
     return {
         apiKey: process.env.SHOPIFY_API_KEY || "",

--- a/apps/shopify/app/routes/app.tsx
+++ b/apps/shopify/app/routes/app.tsx
@@ -9,6 +9,7 @@ import {
     ensureWalletUrlMetafield,
     resolveMerchantId,
 } from "app/services.server/merchant";
+import { ensureFrakI18nMetafieldDefinitions } from "app/services.server/metafields";
 import { shopInfo } from "app/services.server/shop";
 import { doesThemeSupportBlock } from "app/services.server/theme";
 import { shouldShowOutletSkeleton } from "app/utils/navigationLoading";
@@ -47,6 +48,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // a ready-to-use share CTA into their email templates without
     // hard-coding the storefront host.
     ensureKlaviyoShareMetafields(context).catch(() => {});
+    // Fire-and-forget: register translatable text metafield definitions so
+    // Translate & Adapt can surface per-locale editors for banner / share
+    // button / post-purchase strings.
+    ensureFrakI18nMetafieldDefinitions(context).catch(() => {});
 
     return {
         apiKey: process.env.SHOPIFY_API_KEY || "",

--- a/apps/shopify/app/services.server/metafields.ts
+++ b/apps/shopify/app/services.server/metafields.ts
@@ -570,7 +570,7 @@ async function readFrakI18nState(
 ): Promise<{ definitionExists: boolean; entryId: string | null } | null> {
     const data = await runGraphQL<{
         metaobjectDefinitionByType?: { id?: string } | null;
-        metaobject?: { id?: string } | null;
+        metaobjectByHandle?: { id?: string } | null;
     }>(
         context.admin.graphql,
         "state read",
@@ -580,7 +580,7 @@ async function readFrakI18nState(
             $entryHandle: MetaobjectHandleInput!
         ) {
             metaobjectDefinitionByType(type: $type) { id }
-            metaobject(handle: $entryHandle) { id }
+            metaobjectByHandle(handle: $entryHandle) { id }
         }`,
         {
             type: FRAK_I18N_METAOBJECT_TYPE,
@@ -593,7 +593,7 @@ async function readFrakI18nState(
     if (!data) return null;
     return {
         definitionExists: Boolean(data.metaobjectDefinitionByType?.id),
-        entryId: data.metaobject?.id ?? null,
+        entryId: data.metaobjectByHandle?.id ?? null,
     };
 }
 

--- a/apps/shopify/app/services.server/metafields.ts
+++ b/apps/shopify/app/services.server/metafields.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedContext } from "app/types/context";
+import { LRUCache } from "lru-cache";
 import { shopInfo } from "./shop";
 
 const FRAK_NAMESPACE = "frak";
@@ -9,6 +10,117 @@ const WALLET_URL_KEY = "wallet_url";
 const COMPONENTS_URL_KEY = "components_url";
 const SHARE_URL_KEY = "share_url";
 const SHARE_BUTTON_HTML_KEY = "share_button_html";
+
+/* -------------------------------------------------------------------------- */
+/*                Translatable text metafield definitions                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Per-locale merchant-customisable strings for the banner block, the
+ * referral share button, and the post-purchase checkout extension.
+ *
+ * These are SHOP-owned metafields with text types (translatable by
+ * Shopify's Translate & Adapt app). Each surface falls back through:
+ *   block setting (when present) → this metafield → locale JSON (when
+ *   surface supports it) → SDK default.
+ *
+ * Existing block settings still win, so theme upgrades remain backwards
+ * compatible.
+ */
+export type FrakI18nMetafieldDefinition = {
+    key: string;
+    name: string;
+    description: string;
+    /** `single_line_text_field` for one-liners, `multi_line_text_field` for descriptions. */
+    type: "single_line_text_field" | "multi_line_text_field";
+};
+
+export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
+    {
+        key: "banner_referral_title",
+        name: "Banner — Referral title",
+        description:
+            "Referral banner heading shown to referred storefront visitors.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "banner_referral_description",
+        name: "Banner — Referral description",
+        description: "Referral banner body shown under the heading.",
+        type: "multi_line_text_field",
+    },
+    {
+        key: "banner_referral_cta",
+        name: "Banner — Referral button",
+        description: "Referral banner call-to-action label.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "banner_inapp_title",
+        name: "Banner — In-app browser title",
+        description:
+            "Heading shown when the storefront opens in Instagram or Facebook's in-app browser.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "banner_inapp_description",
+        name: "Banner — In-app browser description",
+        description:
+            "Body shown when the storefront opens in an in-app browser.",
+        type: "multi_line_text_field",
+    },
+    {
+        key: "banner_inapp_cta",
+        name: "Banner — In-app browser button",
+        description: "Call-to-action label for the in-app browser banner.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "button_share_text",
+        name: "Share button — Label",
+        description:
+            "Storefront share button label. Use {REWARD} to embed the reward amount.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "button_share_no_reward_text",
+        name: "Share button — Fallback label",
+        description:
+            "Label shown when rewards are enabled on the share button but no reward is available.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "post_purchase_message",
+        name: "Post-purchase — Heading",
+        description: "Heading on the post-purchase sharing card.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "post_purchase_description",
+        name: "Post-purchase — Description",
+        description: "Body copy on the post-purchase sharing card.",
+        type: "multi_line_text_field",
+    },
+    {
+        key: "post_purchase_cta_text",
+        name: "Post-purchase — Button",
+        description: "Call-to-action label on the post-purchase sharing card.",
+        type: "single_line_text_field",
+    },
+    {
+        key: "post_purchase_badge_text",
+        name: "Post-purchase — Badge",
+        description:
+            "Optional pill label above the heading. Leave empty to hide.",
+        type: "single_line_text_field",
+    },
+];
+
+/**
+ * Metafield definition userError codes we can safely ignore.
+ * `TAKEN` → the definition already exists (idempotent path).
+ */
+const IGNORABLE_DEFINITION_ERROR_CODES = new Set(["TAKEN"]);
 
 export type AppearanceMetafieldValue = {
     logoUrl?: string;
@@ -362,6 +474,107 @@ export async function writeMerchantIdMetafield(
 export async function getShopId(ctx: AuthenticatedContext): Promise<string> {
     const info = await shopInfo(ctx);
     return info.id;
+}
+
+/* -------------------------------------------------------------------------- */
+/*              Translatable text metafield definition setup                  */
+/* -------------------------------------------------------------------------- */
+
+const i18nDefinitionsSyncedShops = new LRUCache<string, boolean>({
+    max: 512,
+    ttl: 30 * 60_000,
+});
+
+/**
+ * Register a single shop-owned metafield definition.
+ *
+ * Idempotent: re-running for an existing definition returns the `TAKEN`
+ * userError code which we treat as success.
+ */
+async function createFrakI18nMetafieldDefinition(
+    { admin: { graphql } }: AuthenticatedContext,
+    definition: FrakI18nMetafieldDefinition
+): Promise<{ ok: boolean; errors: Array<{ code?: string; message: string }> }> {
+    const response = await graphql(
+        `#graphql
+        mutation CreateFrakI18nMetafieldDefinition(
+            $definition: MetafieldDefinitionInput!
+        ) {
+            metafieldDefinitionCreate(definition: $definition) {
+                createdDefinition { id }
+                userErrors { field message code }
+            }
+        }`,
+        {
+            variables: {
+                definition: {
+                    name: definition.name,
+                    namespace: FRAK_NAMESPACE,
+                    key: definition.key,
+                    description: definition.description,
+                    type: definition.type,
+                    ownerType: "SHOP",
+                    access: {
+                        admin: "MERCHANT_READ_WRITE",
+                        storefront: "PUBLIC_READ",
+                    },
+                },
+            },
+        }
+    );
+
+    const {
+        data: { metafieldDefinitionCreate },
+    } = await response.json();
+
+    const errors = (metafieldDefinitionCreate?.userErrors ?? []) as Array<{
+        code?: string;
+        message: string;
+    }>;
+    const blockingErrors = errors.filter(
+        (e) => !e.code || !IGNORABLE_DEFINITION_ERROR_CODES.has(e.code)
+    );
+
+    return { ok: blockingErrors.length === 0, errors: blockingErrors };
+}
+
+/**
+ * Ensure every translatable Frak text metafield definition exists on the
+ * shop. Definitions enable Shopify's Translate & Adapt app to discover
+ * the metafields and offer per-locale translation editors.
+ *
+ * Fire-and-forget; cached per shop for 30 minutes (same pattern as
+ * `ensureWalletUrlMetafield` in merchant.ts).
+ */
+export async function ensureFrakI18nMetafieldDefinitions(
+    context: AuthenticatedContext
+): Promise<void> {
+    const shop = await shopInfo(context);
+    const cacheKey = shop.normalizedDomain;
+
+    if (i18nDefinitionsSyncedShops.get(cacheKey)) return;
+
+    const results = await Promise.allSettled(
+        FRAK_I18N_METAFIELD_DEFINITIONS.map((def) =>
+            createFrakI18nMetafieldDefinition(context, def)
+        )
+    );
+
+    for (const [index, result] of results.entries()) {
+        if (result.status === "rejected") {
+            console.error(
+                `[frakI18n] definition create failed for ${FRAK_I18N_METAFIELD_DEFINITIONS[index].key}:`,
+                result.reason
+            );
+        } else if (!result.value.ok) {
+            console.error(
+                `[frakI18n] definition rejected for ${FRAK_I18N_METAFIELD_DEFINITIONS[index].key}:`,
+                result.value.errors
+            );
+        }
+    }
+
+    i18nDefinitionsSyncedShops.set(cacheKey, true);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/shopify/app/services.server/metafields.ts
+++ b/apps/shopify/app/services.server/metafields.ts
@@ -12,48 +12,78 @@ const SHARE_URL_KEY = "share_url";
 const SHARE_BUTTON_HTML_KEY = "share_button_html";
 
 /* -------------------------------------------------------------------------- */
-/*                Translatable text metafield definitions                    */
+/*                Translatable text metaobject (Frak i18n)                    */
 /* -------------------------------------------------------------------------- */
 
 /**
  * Per-locale merchant-customisable strings for the banner block, the
  * referral share button, and the post-purchase checkout extension.
  *
- * These are SHOP-owned metafields with text types (translatable by
- * Shopify's Translate & Adapt app). Each surface falls back through:
- *   block setting (when present) → this metafield → locale JSON (when
- *   surface supports it) → SDK default.
+ * Stored as a single merchant-owned metaobject of type `frak_i18n` with
+ * one "default" entry. Surfaces as a dedicated section in Shopify's
+ * Translate & Adapt app, away from the operational shop metafields
+ * (modal_i18n, appearance, merchant_id, …).
  *
- * Existing block settings still win, so theme upgrades remain backwards
- * compatible.
+ * Why merchant-owned (no `$app:` prefix) despite app-owned being the
+ * default for app-managed data: app-owned metaobjects are not reliably
+ * accessible from Liquid theme app extensions (`shop.metaobjects['$app:…']`
+ * returns empty in production stores; documented workarounds rely on the
+ * fully-resolved `app--{app_id}--…` type name). Merchant-owned types
+ * read cleanly via `shop.metaobjects.frak_i18n.default.<field>`.
+ *
+ * Resolution chain per surface:
+ *   block setting → metaobject field → storefront `| t` → SDK default
  */
-export type FrakI18nMetafieldDefinition = {
+
+const FRAK_I18N_METAOBJECT_TYPE = "frak_i18n";
+const FRAK_I18N_SINGLETON_HANDLE = "default";
+const FRAK_I18N_DEFINITION_NAME = "Frak Translations";
+const FRAK_I18N_DEFINITION_DESCRIPTION =
+    "Per-locale text used by the Frak banner, share button, and post-purchase card. Edit non-default languages via Translate & Adapt.";
+const FRAK_I18N_DISPLAY_NAME_FIELD = "banner_referral_title";
+const FRAK_I18N_FR_LOCALE = "fr";
+
+export type FrakI18nFieldDefinition = {
     key: string;
     name: string;
     description: string;
-    /** `single_line_text_field` for one-liners, `multi_line_text_field` for descriptions. */
     type: "single_line_text_field" | "multi_line_text_field";
+    /**
+     * Seed values written on first install. `en` becomes the entry's
+     * field value (source locale); `fr` is registered via
+     * `translationsRegister`. Skipped when undefined.
+     */
+    defaults: { en?: string; fr?: string };
 };
 
-export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
+export const FRAK_I18N_FIELDS: FrakI18nFieldDefinition[] = [
     {
         key: "banner_referral_title",
         name: "Banner — Referral title",
         description:
             "Referral banner heading shown to referred storefront visitors.",
         type: "single_line_text_field",
+        defaults: {
+            en: "You've been referred!",
+            fr: "Vous avez été parrainé !",
+        },
     },
     {
         key: "banner_referral_description",
         name: "Banner — Referral description",
         description: "Referral banner body shown under the heading.",
         type: "multi_line_text_field",
+        defaults: {
+            en: "Make your first purchase to unlock your reward.",
+            fr: "Effectuez votre premier achat pour débloquer votre récompense.",
+        },
     },
     {
         key: "banner_referral_cta",
         name: "Banner — Referral button",
         description: "Referral banner call-to-action label.",
         type: "single_line_text_field",
+        defaults: { en: "Got it", fr: "Compris" },
     },
     {
         key: "banner_inapp_title",
@@ -61,6 +91,10 @@ export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
         description:
             "Heading shown when the storefront opens in Instagram or Facebook's in-app browser.",
         type: "single_line_text_field",
+        defaults: {
+            en: "Open in your browser",
+            fr: "Ouvrir dans votre navigateur",
+        },
     },
     {
         key: "banner_inapp_description",
@@ -68,12 +102,17 @@ export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
         description:
             "Body shown when the storefront opens in an in-app browser.",
         type: "multi_line_text_field",
+        defaults: {
+            en: "For the best experience, open this page in your system browser.",
+            fr: "Pour une meilleure expérience, ouvrez cette page dans le navigateur de votre téléphone.",
+        },
     },
     {
         key: "banner_inapp_cta",
         name: "Banner — In-app browser button",
         description: "Call-to-action label for the in-app browser banner.",
         type: "single_line_text_field",
+        defaults: { en: "Open browser", fr: "Ouvrir le navigateur" },
     },
     {
         key: "button_share_text",
@@ -81,6 +120,7 @@ export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
         description:
             "Storefront share button label. Use {REWARD} to embed the reward amount.",
         type: "single_line_text_field",
+        defaults: { en: "Share and earn!", fr: "Partage et gagne !" },
     },
     {
         key: "button_share_no_reward_text",
@@ -88,24 +128,34 @@ export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
         description:
             "Label shown when rewards are enabled on the share button but no reward is available.",
         type: "single_line_text_field",
+        defaults: { en: "Share and earn!", fr: "Partage et gagne !" },
     },
     {
         key: "post_purchase_message",
         name: "Post-purchase — Heading",
         description: "Heading on the post-purchase sharing card.",
         type: "single_line_text_field",
+        defaults: {
+            en: "Earn rewards through sharing",
+            fr: "Gagnez des récompenses en partageant",
+        },
     },
     {
         key: "post_purchase_description",
         name: "Post-purchase — Description",
         description: "Body copy on the post-purchase sharing card.",
         type: "multi_line_text_field",
+        defaults: {
+            en: "If they buy, they earn... and so do you!",
+            fr: "S'ils achètent, ils gagnent… et vous aussi !",
+        },
     },
     {
         key: "post_purchase_cta_text",
         name: "Post-purchase — Button",
         description: "Call-to-action label on the post-purchase sharing card.",
         type: "single_line_text_field",
+        defaults: { en: "Share & earn", fr: "Partager & gagner" },
     },
     {
         key: "post_purchase_badge_text",
@@ -113,14 +163,9 @@ export const FRAK_I18N_METAFIELD_DEFINITIONS: FrakI18nMetafieldDefinition[] = [
         description:
             "Optional pill label above the heading. Leave empty to hide.",
         type: "single_line_text_field",
+        defaults: {},
     },
 ];
-
-/**
- * Metafield definition userError codes we can safely ignore.
- * `TAKEN` → the definition already exists (idempotent path).
- */
-const IGNORABLE_DEFINITION_ERROR_CODES = new Set(["TAKEN"]);
 
 export type AppearanceMetafieldValue = {
     logoUrl?: string;
@@ -477,104 +522,487 @@ export async function getShopId(ctx: AuthenticatedContext): Promise<string> {
 }
 
 /* -------------------------------------------------------------------------- */
-/*              Translatable text metafield definition setup                  */
+/*              Frak i18n metaobject — singleton entry orchestrator           */
 /* -------------------------------------------------------------------------- */
 
-const i18nDefinitionsSyncedShops = new LRUCache<string, boolean>({
+const i18nMetaobjectSyncedShops = new LRUCache<string, boolean>({
     max: 512,
     ttl: 30 * 60_000,
 });
 
-/**
- * Register a single shop-owned metafield definition.
- *
- * Idempotent: re-running for an existing definition returns the `TAKEN`
- * userError code which we treat as success.
- */
-async function createFrakI18nMetafieldDefinition(
-    { admin: { graphql } }: AuthenticatedContext,
-    definition: FrakI18nMetafieldDefinition
-): Promise<{ ok: boolean; errors: Array<{ code?: string; message: string }> }> {
+const IGNORABLE_METAOBJECT_DEFINITION_ERROR_CODES = new Set(["TAKEN"]);
+
+type GraphQLBody<TData> = {
+    data?: TData;
+    errors?: Array<{ message: string }>;
+};
+
+async function ensureFrakI18nDefinition({
+    admin: { graphql },
+}: AuthenticatedContext): Promise<{ ok: boolean; alreadyExists: boolean }> {
+    const existing = await graphql(
+        `#graphql
+        query ReadFrakI18nDefinition($type: String!) {
+            metaobjectDefinitionByType(type: $type) { id }
+        }`,
+        { variables: { type: FRAK_I18N_METAOBJECT_TYPE } }
+    );
+    const existingBody = (await existing.json()) as GraphQLBody<{
+        metaobjectDefinitionByType?: { id?: string } | null;
+    }>;
+    if (existingBody.errors?.length) {
+        console.error(
+            "[frakI18n] definition read top-level errors:",
+            existingBody.errors
+        );
+    }
+    if (existingBody.data?.metaobjectDefinitionByType?.id) {
+        return { ok: true, alreadyExists: true };
+    }
+
     const response = await graphql(
         `#graphql
-        mutation CreateFrakI18nMetafieldDefinition(
-            $definition: MetafieldDefinitionInput!
+        mutation CreateFrakI18nDefinition(
+            $definition: MetaobjectDefinitionCreateInput!
         ) {
-            metafieldDefinitionCreate(definition: $definition) {
-                createdDefinition { id }
+            metaobjectDefinitionCreate(definition: $definition) {
+                metaobjectDefinition { id }
                 userErrors { field message code }
             }
         }`,
         {
             variables: {
                 definition: {
-                    name: definition.name,
-                    namespace: FRAK_NAMESPACE,
-                    key: definition.key,
-                    description: definition.description,
-                    type: definition.type,
-                    ownerType: "SHOP",
-                    access: {
-                        admin: "MERCHANT_READ_WRITE",
-                        storefront: "PUBLIC_READ",
+                    type: FRAK_I18N_METAOBJECT_TYPE,
+                    name: FRAK_I18N_DEFINITION_NAME,
+                    description: FRAK_I18N_DEFINITION_DESCRIPTION,
+                    displayNameKey: FRAK_I18N_DISPLAY_NAME_FIELD,
+                    access: { storefront: "PUBLIC_READ" },
+                    capabilities: {
+                        publishable: { enabled: true },
+                        translatable: { enabled: true },
                     },
+                    fieldDefinitions: FRAK_I18N_FIELDS.map((f) => ({
+                        key: f.key,
+                        name: f.name,
+                        description: f.description,
+                        type: f.type,
+                    })),
                 },
             },
         }
     );
-
-    const {
-        data: { metafieldDefinitionCreate },
-    } = await response.json();
-
-    const errors = (metafieldDefinitionCreate?.userErrors ?? []) as Array<{
-        code?: string;
-        message: string;
+    const body = (await response.json()) as GraphQLBody<{
+        metaobjectDefinitionCreate?: {
+            userErrors?: Array<{ code?: string; message: string }>;
+        };
     }>;
-    const blockingErrors = errors.filter(
-        (e) => !e.code || !IGNORABLE_DEFINITION_ERROR_CODES.has(e.code)
+    if (body.errors?.length) {
+        console.error(
+            "[frakI18n] definition create top-level errors:",
+            body.errors
+        );
+        return { ok: false, alreadyExists: false };
+    }
+    const errors = body.data?.metaobjectDefinitionCreate?.userErrors ?? [];
+    const blocking = errors.filter(
+        (e) =>
+            !e.code || !IGNORABLE_METAOBJECT_DEFINITION_ERROR_CODES.has(e.code)
     );
-
-    return { ok: blockingErrors.length === 0, errors: blockingErrors };
+    if (blocking.length > 0) {
+        console.error(
+            "[frakI18n] definition create rejected:",
+            JSON.stringify(blocking)
+        );
+    }
+    return { ok: blocking.length === 0, alreadyExists: false };
 }
 
+type FrakI18nUpsertResult = {
+    id: string | null;
+    errorMessages: string[];
+};
+
 /**
- * Ensure every translatable Frak text metafield definition exists on the
- * shop. Definitions enable Shopify's Translate & Adapt app to discover
- * the metafields and offer per-locale translation editors.
- *
- * Fire-and-forget; cached per shop for 30 minutes (same pattern as
- * `ensureWalletUrlMetafield` in merchant.ts).
+ * Atomic create-or-update of the singleton entry. Each EN seed value
+ * is overwritten on every run (cheap) so the entry self-heals if a
+ * previous attempt left it half-populated. `publishable.status = ACTIVE`
+ * requires the definition's `publishable: { enabled: true }` capability
+ * — missing that flag yields `CAPABILITY_NOT_ENABLED` from Shopify.
  */
-export async function ensureFrakI18nMetafieldDefinitions(
+async function upsertFrakI18nEntry({
+    admin: { graphql },
+}: AuthenticatedContext): Promise<FrakI18nUpsertResult> {
+    const fields = FRAK_I18N_FIELDS.flatMap((f) =>
+        f.defaults.en ? [{ key: f.key, value: f.defaults.en }] : []
+    );
+    const response = await graphql(
+        `#graphql
+        mutation UpsertFrakI18nEntry(
+            $handle: MetaobjectHandleInput!
+            $metaobject: MetaobjectUpsertInput!
+        ) {
+            metaobjectUpsert(handle: $handle, metaobject: $metaobject) {
+                metaobject { id }
+                userErrors { field message code }
+            }
+        }`,
+        {
+            variables: {
+                handle: {
+                    type: FRAK_I18N_METAOBJECT_TYPE,
+                    handle: FRAK_I18N_SINGLETON_HANDLE,
+                },
+                metaobject: {
+                    fields,
+                    capabilities: { publishable: { status: "ACTIVE" } },
+                },
+            },
+        }
+    );
+    const body = (await response.json()) as GraphQLBody<{
+        metaobjectUpsert?: {
+            metaobject?: { id?: string } | null;
+            userErrors?: Array<{
+                field?: string[];
+                message: string;
+                code?: string;
+            }>;
+        };
+    }>;
+    const errorMessages: string[] = [];
+    if (body.errors?.length) {
+        console.error("[frakI18n] entry upsert top-level errors:", body.errors);
+        for (const e of body.errors)
+            errorMessages.push(`top-level: ${e.message}`);
+    }
+    const result = body.data?.metaobjectUpsert;
+    if (result?.userErrors?.length) {
+        console.error(
+            "[frakI18n] entry upsert userErrors:",
+            JSON.stringify(result.userErrors)
+        );
+        for (const e of result.userErrors) {
+            const path = e.field?.join(".") ?? "(no field)";
+            const code = e.code ? `[${e.code}] ` : "";
+            errorMessages.push(`${code}${path}: ${e.message}`);
+        }
+    }
+    return { id: result?.metaobject?.id ?? null, errorMessages };
+}
+
+type FrakI18nFieldTranslationState = {
+    digestByKey: Map<string, string>;
+    keysWithFr: Set<string>;
+};
+
+/**
+ * Fetch translatable digests + existing FR translations for the singleton
+ * entry. Unlike metafields (one translatable "value" key), metaobjects
+ * expose one translatable entry PER field — so the digest map is keyed
+ * by our field keys directly.
+ */
+async function readFrakI18nFieldTranslationState(
+    { admin: { graphql } }: AuthenticatedContext,
+    entryId: string
+): Promise<FrakI18nFieldTranslationState> {
+    const response = await graphql(
+        `#graphql
+        query ReadFrakI18nFieldTranslationState(
+            $resourceIds: [ID!]!
+            $locale: String!
+        ) {
+            translatableResourcesByIds(first: 1, resourceIds: $resourceIds) {
+                nodes {
+                    resourceId
+                    translatableContent { key value digest locale }
+                    translations(locale: $locale) { key locale value }
+                }
+            }
+        }`,
+        {
+            variables: {
+                resourceIds: [entryId],
+                locale: FRAK_I18N_FR_LOCALE,
+            },
+        }
+    );
+    const { data } = await response.json();
+    const node = data?.translatableResourcesByIds?.nodes?.[0];
+    const digestByKey = new Map<string, string>();
+    const keysWithFr = new Set<string>();
+    for (const c of node?.translatableContent ?? []) {
+        if (typeof c.digest === "string") digestByKey.set(c.key, c.digest);
+    }
+    for (const t of node?.translations ?? []) {
+        if (typeof t.value === "string" && t.value.length > 0)
+            keysWithFr.add(t.key);
+    }
+    return { digestByKey, keysWithFr };
+}
+
+async function registerFrakI18nFrTranslations(
+    { admin: { graphql } }: AuthenticatedContext,
+    entryId: string,
+    translations: Array<{ key: string; value: string; digest: string }>
+): Promise<{ ok: boolean; errors: Array<{ message: string }> }> {
+    if (translations.length === 0) return { ok: true, errors: [] };
+    const response = await graphql(
+        `#graphql
+        mutation RegisterFrakI18nFrTranslations(
+            $resourceId: ID!
+            $translations: [TranslationInput!]!
+        ) {
+            translationsRegister(
+                resourceId: $resourceId
+                translations: $translations
+            ) {
+                translations { key value locale }
+                userErrors { field message code }
+            }
+        }`,
+        {
+            variables: {
+                resourceId: entryId,
+                translations: translations.map((t) => ({
+                    locale: FRAK_I18N_FR_LOCALE,
+                    key: t.key,
+                    value: t.value,
+                    translatableContentDigest: t.digest,
+                })),
+            },
+        }
+    );
+    const body = (await response.json()) as GraphQLBody<{
+        translationsRegister?: {
+            userErrors?: Array<{ message: string }>;
+        };
+    }>;
+    if (body.errors?.length) {
+        console.error("[frakI18n] fr register top-level errors:", body.errors);
+        return {
+            ok: false,
+            errors: body.errors.map((e) => ({ message: e.message })),
+        };
+    }
+    const errors = body.data?.translationsRegister?.userErrors ?? [];
+    return { ok: errors.length === 0, errors };
+}
+
+export type FrakI18nSyncResult = {
+    definitionOk: boolean;
+    entryId: string | null;
+    frTranslationsRegistered: number;
+    errors: string[];
+};
+
+/**
+ * Idempotent: ensure the `frak_i18n` metaobject definition exists,
+ * upsert the singleton entry with bundled EN values, then register the
+ * bundled FR translations for any field that doesn't already have one
+ * (preserving merchant overrides).
+ *
+ * Cached per shop for 30 minutes — but only on full success. Partial
+ * failures stay retryable so a later loader can recover. Pass
+ * `bypassCache=true` to force a re-run (used by the debug action).
+ */
+export async function ensureFrakI18nMetaobject(
+    context: AuthenticatedContext,
+    { bypassCache = false }: { bypassCache?: boolean } = {}
+): Promise<FrakI18nSyncResult> {
+    const shop = await shopInfo(context);
+    const cacheKey = shop.normalizedDomain;
+    const result: FrakI18nSyncResult = {
+        definitionOk: false,
+        entryId: null,
+        frTranslationsRegistered: 0,
+        errors: [],
+    };
+    if (!bypassCache && i18nMetaobjectSyncedShops.get(cacheKey)) {
+        result.definitionOk = true;
+        return result;
+    }
+
+    try {
+        const { ok } = await ensureFrakI18nDefinition(context);
+        result.definitionOk = ok;
+        if (!ok) {
+            result.errors.push("definition: create or read failed");
+            return result;
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("[frakI18n] definition ensure threw:", error);
+        result.errors.push(`definition: ${message}`);
+        return result;
+    }
+
+    try {
+        const upsert = await upsertFrakI18nEntry(context);
+        result.entryId = upsert.id;
+        for (const msg of upsert.errorMessages) {
+            result.errors.push(`entry: ${msg}`);
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("[frakI18n] entry upsert threw:", error);
+        result.errors.push(`entry: ${message}`);
+        return result;
+    }
+    if (!result.entryId) {
+        if (result.errors.length === 0) {
+            result.errors.push(
+                "entry: metaobjectUpsert returned no id (no userErrors surfaced)"
+            );
+        }
+        return result;
+    }
+
+    await syncFrakI18nFrTranslations(context, result);
+
+    if (result.errors.length === 0) {
+        i18nMetaobjectSyncedShops.set(cacheKey, true);
+    }
+    return result;
+}
+
+async function syncFrakI18nFrTranslations(
+    context: AuthenticatedContext,
+    result: FrakI18nSyncResult
+): Promise<void> {
+    if (!result.entryId) return;
+    try {
+        const state = await readFrakI18nFieldTranslationState(
+            context,
+            result.entryId
+        );
+        const missing = FRAK_I18N_FIELDS.flatMap((f) => {
+            if (!f.defaults.fr) return [];
+            if (state.keysWithFr.has(f.key)) return [];
+            const digest = state.digestByKey.get(f.key);
+            if (!digest) return [];
+            return [{ key: f.key, value: f.defaults.fr, digest }];
+        });
+        const { ok, errors } = await registerFrakI18nFrTranslations(
+            context,
+            result.entryId,
+            missing
+        );
+        if (ok) {
+            result.frTranslationsRegistered = missing.length;
+        } else {
+            console.error("[frakI18n] fr translations rejected:", errors);
+            result.errors.push(
+                `fr translations: ${errors.map((e) => e.message).join("; ")}`
+            );
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("[frakI18n] fr translation step threw:", error);
+        result.errors.push(`fr translations: ${message}`);
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/*              Legacy i18n metafield cleanup (one-time migration)            */
+/* -------------------------------------------------------------------------- */
+
+const LEGACY_FRAK_I18N_METAFIELD_KEYS = new Set([
+    "banner_referral_title",
+    "banner_referral_description",
+    "banner_referral_cta",
+    "banner_inapp_title",
+    "banner_inapp_description",
+    "banner_inapp_cta",
+    "button_share_text",
+    "button_share_no_reward_text",
+    "post_purchase_message",
+    "post_purchase_description",
+    "post_purchase_cta_text",
+    "post_purchase_badge_text",
+]);
+
+const legacyI18nCleanupShops = new LRUCache<string, boolean>({
+    max: 512,
+    ttl: 24 * 60 * 60_000,
+});
+
+/**
+ * Delete the legacy translatable text metafield definitions on the
+ * shop's `frak` namespace, including any merchant-written values and
+ * registered translations. Idempotent + LRU-cached 24h so it runs once
+ * per shop per day.
+ *
+ * Other `frak.*` metafields (modal_i18n, appearance, merchant_id,
+ * wallet_url, components_url, share_url, share_button_html) are
+ * preserved — only the 12 keys in `LEGACY_FRAK_I18N_METAFIELD_KEYS`
+ * are removed.
+ */
+export async function cleanupLegacyFrakI18nMetafields(
     context: AuthenticatedContext
 ): Promise<void> {
     const shop = await shopInfo(context);
     const cacheKey = shop.normalizedDomain;
+    if (legacyI18nCleanupShops.get(cacheKey)) return;
 
-    if (i18nDefinitionsSyncedShops.get(cacheKey)) return;
+    const { admin } = context;
+    let definitionsToDelete: Array<{ id: string; key: string }>;
+    try {
+        const response = await admin.graphql(
+            `#graphql
+            query ListLegacyFrakI18nDefinitions($namespace: String!) {
+                metafieldDefinitions(
+                    namespace: $namespace
+                    ownerType: SHOP
+                    first: 100
+                ) {
+                    nodes { id key }
+                }
+            }`,
+            { variables: { namespace: FRAK_NAMESPACE } }
+        );
+        const { data } = await response.json();
+        const nodes: Array<{ id: string; key: string }> =
+            data?.metafieldDefinitions?.nodes ?? [];
+        definitionsToDelete = nodes.filter((d) =>
+            LEGACY_FRAK_I18N_METAFIELD_KEYS.has(d.key)
+        );
+    } catch (error) {
+        console.error("[frakI18n] legacy cleanup list failed:", error);
+        return;
+    }
+
+    if (definitionsToDelete.length === 0) {
+        legacyI18nCleanupShops.set(cacheKey, true);
+        return;
+    }
 
     const results = await Promise.allSettled(
-        FRAK_I18N_METAFIELD_DEFINITIONS.map((def) =>
-            createFrakI18nMetafieldDefinition(context, def)
+        definitionsToDelete.map((def) =>
+            admin.graphql(
+                `#graphql
+                mutation DeleteLegacyFrakI18nDefinition($id: ID!) {
+                    metafieldDefinitionDelete(
+                        id: $id
+                        deleteAllAssociatedMetafields: true
+                    ) {
+                        deletedDefinitionId
+                        userErrors { field message code }
+                    }
+                }`,
+                { variables: { id: def.id } }
+            )
         )
     );
-
-    for (const [index, result] of results.entries()) {
+    for (const [i, result] of results.entries()) {
         if (result.status === "rejected") {
             console.error(
-                `[frakI18n] definition create failed for ${FRAK_I18N_METAFIELD_DEFINITIONS[index].key}:`,
+                `[frakI18n] legacy def delete failed for ${definitionsToDelete[i].key}:`,
                 result.reason
-            );
-        } else if (!result.value.ok) {
-            console.error(
-                `[frakI18n] definition rejected for ${FRAK_I18N_METAFIELD_DEFINITIONS[index].key}:`,
-                result.value.errors
             );
         }
     }
-
-    i18nDefinitionsSyncedShops.set(cacheKey, true);
+    legacyI18nCleanupShops.set(cacheKey, true);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/shopify/app/services.server/metafields.ts
+++ b/apps/shopify/app/services.server/metafields.ts
@@ -40,7 +40,6 @@ const FRAK_I18N_SINGLETON_HANDLE = "default";
 const FRAK_I18N_DEFINITION_NAME = "Frak Translations";
 const FRAK_I18N_DEFINITION_DESCRIPTION =
     "Per-locale text used by the Frak banner, share button, and post-purchase card. Edit non-default languages via Translate & Adapt.";
-const FRAK_I18N_DISPLAY_NAME_FIELD = "banner_referral_title";
 const FRAK_I18N_FR_LOCALE = "fr";
 
 export type FrakI18nFieldDefinition = {
@@ -537,30 +536,77 @@ type GraphQLBody<TData> = {
     errors?: Array<{ message: string }>;
 };
 
-async function ensureFrakI18nDefinition({
-    admin: { graphql },
-}: AuthenticatedContext): Promise<{ ok: boolean; alreadyExists: boolean }> {
-    const existing = await graphql(
-        `#graphql
-        query ReadFrakI18nDefinition($type: String!) {
-            metaobjectDefinitionByType(type: $type) { id }
-        }`,
-        { variables: { type: FRAK_I18N_METAOBJECT_TYPE } }
-    );
-    const existingBody = (await existing.json()) as GraphQLBody<{
-        metaobjectDefinitionByType?: { id?: string } | null;
-    }>;
-    if (existingBody.errors?.length) {
-        console.error(
-            "[frakI18n] definition read top-level errors:",
-            existingBody.errors
-        );
+/**
+ * Boilerplate-free GraphQL call. Logs and returns `null` on transport
+ * errors, JSON parse failures, or top-level GraphQL errors; callers
+ * handle `userErrors` from the returned data.
+ */
+async function runGraphQL<TData>(
+    graphql: AuthenticatedContext["admin"]["graphql"],
+    label: string,
+    query: string,
+    variables: Record<string, unknown>
+): Promise<TData | null> {
+    try {
+        const response = await graphql(query, { variables });
+        const body = (await response.json()) as GraphQLBody<TData>;
+        if (body.errors?.length) {
+            console.error(`[frakI18n] ${label} top-level errors:`, body.errors);
+            return null;
+        }
+        return body.data ?? null;
+    } catch (error) {
+        console.error(`[frakI18n] ${label} threw:`, error);
+        return null;
     }
-    if (existingBody.data?.metaobjectDefinitionByType?.id) {
-        return { ok: true, alreadyExists: true };
-    }
+}
 
-    const response = await graphql(
+/**
+ * Single round-trip read of the singleton state. The orchestrator uses
+ * this to decide whether to create the definition and/or seed the entry.
+ */
+async function readFrakI18nState(
+    context: AuthenticatedContext
+): Promise<{ definitionExists: boolean; entryId: string | null } | null> {
+    const data = await runGraphQL<{
+        metaobjectDefinitionByType?: { id?: string } | null;
+        metaobject?: { id?: string } | null;
+    }>(
+        context.admin.graphql,
+        "state read",
+        `#graphql
+        query ReadFrakI18nState(
+            $type: String!
+            $entryHandle: MetaobjectHandleInput!
+        ) {
+            metaobjectDefinitionByType(type: $type) { id }
+            metaobject(handle: $entryHandle) { id }
+        }`,
+        {
+            type: FRAK_I18N_METAOBJECT_TYPE,
+            entryHandle: {
+                type: FRAK_I18N_METAOBJECT_TYPE,
+                handle: FRAK_I18N_SINGLETON_HANDLE,
+            },
+        }
+    );
+    if (!data) return null;
+    return {
+        definitionExists: Boolean(data.metaobjectDefinitionByType?.id),
+        entryId: data.metaobject?.id ?? null,
+    };
+}
+
+async function createFrakI18nDefinition(
+    context: AuthenticatedContext
+): Promise<boolean> {
+    const data = await runGraphQL<{
+        metaobjectDefinitionCreate?: {
+            userErrors?: Array<{ code?: string; message: string }>;
+        };
+    }>(
+        context.admin.graphql,
+        "definition create",
         `#graphql
         mutation CreateFrakI18nDefinition(
             $definition: MetaobjectDefinitionCreateInput!
@@ -571,40 +617,26 @@ async function ensureFrakI18nDefinition({
             }
         }`,
         {
-            variables: {
-                definition: {
-                    type: FRAK_I18N_METAOBJECT_TYPE,
-                    name: FRAK_I18N_DEFINITION_NAME,
-                    description: FRAK_I18N_DEFINITION_DESCRIPTION,
-                    displayNameKey: FRAK_I18N_DISPLAY_NAME_FIELD,
-                    access: { storefront: "PUBLIC_READ" },
-                    capabilities: {
-                        publishable: { enabled: true },
-                        translatable: { enabled: true },
-                    },
-                    fieldDefinitions: FRAK_I18N_FIELDS.map((f) => ({
-                        key: f.key,
-                        name: f.name,
-                        description: f.description,
-                        type: f.type,
-                    })),
+            definition: {
+                type: FRAK_I18N_METAOBJECT_TYPE,
+                name: FRAK_I18N_DEFINITION_NAME,
+                description: FRAK_I18N_DEFINITION_DESCRIPTION,
+                access: { storefront: "PUBLIC_READ" },
+                capabilities: {
+                    publishable: { enabled: true },
+                    translatable: { enabled: true },
                 },
+                fieldDefinitions: FRAK_I18N_FIELDS.map((f) => ({
+                    key: f.key,
+                    name: f.name,
+                    description: f.description,
+                    type: f.type,
+                })),
             },
         }
     );
-    const body = (await response.json()) as GraphQLBody<{
-        metaobjectDefinitionCreate?: {
-            userErrors?: Array<{ code?: string; message: string }>;
-        };
-    }>;
-    if (body.errors?.length) {
-        console.error(
-            "[frakI18n] definition create top-level errors:",
-            body.errors
-        );
-        return { ok: false, alreadyExists: false };
-    }
-    const errors = body.data?.metaobjectDefinitionCreate?.userErrors ?? [];
+    if (!data) return false;
+    const errors = data.metaobjectDefinitionCreate?.userErrors ?? [];
     const blocking = errors.filter(
         (e) =>
             !e.code || !IGNORABLE_METAOBJECT_DEFINITION_ERROR_CODES.has(e.code)
@@ -614,29 +646,35 @@ async function ensureFrakI18nDefinition({
             "[frakI18n] definition create rejected:",
             JSON.stringify(blocking)
         );
+        return false;
     }
-    return { ok: blocking.length === 0, alreadyExists: false };
+    return true;
 }
 
-type FrakI18nUpsertResult = {
-    id: string | null;
-    errorMessages: string[];
-};
-
 /**
- * Atomic create-or-update of the singleton entry. Each EN seed value
- * is overwritten on every run (cheap) so the entry self-heals if a
- * previous attempt left it half-populated. `publishable.status = ACTIVE`
- * requires the definition's `publishable: { enabled: true }` capability
- * — missing that flag yields `CAPABILITY_NOT_ENABLED` from Shopify.
+ * Create the singleton entry with bundled EN seeds. Only invoked when
+ * the state read confirmed no entry exists yet, so merchant edits on
+ * existing EN values are never overwritten. `publishable.status = ACTIVE`
+ * requires the definition's `publishable: { enabled: true }` capability.
  */
-async function upsertFrakI18nEntry({
-    admin: { graphql },
-}: AuthenticatedContext): Promise<FrakI18nUpsertResult> {
+async function upsertFrakI18nEntry(
+    context: AuthenticatedContext
+): Promise<string | null> {
     const fields = FRAK_I18N_FIELDS.flatMap((f) =>
         f.defaults.en ? [{ key: f.key, value: f.defaults.en }] : []
     );
-    const response = await graphql(
+    const data = await runGraphQL<{
+        metaobjectUpsert?: {
+            metaobject?: { id?: string } | null;
+            userErrors?: Array<{
+                field?: string[];
+                message: string;
+                code?: string;
+            }>;
+        };
+    }>(
+        context.admin.graphql,
+        "entry upsert",
         `#graphql
         mutation UpsertFrakI18nEntry(
             $handle: MetaobjectHandleInput!
@@ -648,47 +686,25 @@ async function upsertFrakI18nEntry({
             }
         }`,
         {
-            variables: {
-                handle: {
-                    type: FRAK_I18N_METAOBJECT_TYPE,
-                    handle: FRAK_I18N_SINGLETON_HANDLE,
-                },
-                metaobject: {
-                    fields,
-                    capabilities: { publishable: { status: "ACTIVE" } },
-                },
+            handle: {
+                type: FRAK_I18N_METAOBJECT_TYPE,
+                handle: FRAK_I18N_SINGLETON_HANDLE,
+            },
+            metaobject: {
+                fields,
+                capabilities: { publishable: { status: "ACTIVE" } },
             },
         }
     );
-    const body = (await response.json()) as GraphQLBody<{
-        metaobjectUpsert?: {
-            metaobject?: { id?: string } | null;
-            userErrors?: Array<{
-                field?: string[];
-                message: string;
-                code?: string;
-            }>;
-        };
-    }>;
-    const errorMessages: string[] = [];
-    if (body.errors?.length) {
-        console.error("[frakI18n] entry upsert top-level errors:", body.errors);
-        for (const e of body.errors)
-            errorMessages.push(`top-level: ${e.message}`);
-    }
-    const result = body.data?.metaobjectUpsert;
+    if (!data) return null;
+    const result = data.metaobjectUpsert;
     if (result?.userErrors?.length) {
         console.error(
             "[frakI18n] entry upsert userErrors:",
             JSON.stringify(result.userErrors)
         );
-        for (const e of result.userErrors) {
-            const path = e.field?.join(".") ?? "(no field)";
-            const code = e.code ? `[${e.code}] ` : "";
-            errorMessages.push(`${code}${path}: ${e.message}`);
-        }
     }
-    return { id: result?.metaobject?.id ?? null, errorMessages };
+    return result?.metaobject?.id ?? null;
 }
 
 type FrakI18nFieldTranslationState = {
@@ -703,10 +719,19 @@ type FrakI18nFieldTranslationState = {
  * by our field keys directly.
  */
 async function readFrakI18nFieldTranslationState(
-    { admin: { graphql } }: AuthenticatedContext,
+    context: AuthenticatedContext,
     entryId: string
-): Promise<FrakI18nFieldTranslationState> {
-    const response = await graphql(
+): Promise<FrakI18nFieldTranslationState | null> {
+    const data = await runGraphQL<{
+        translatableResourcesByIds?: {
+            nodes?: Array<{
+                translatableContent?: Array<{ key: string; digest?: string }>;
+                translations?: Array<{ key: string; value?: string }>;
+            }>;
+        };
+    }>(
+        context.admin.graphql,
+        "translation state read",
         `#graphql
         query ReadFrakI18nFieldTranslationState(
             $resourceIds: [ID!]!
@@ -714,21 +739,15 @@ async function readFrakI18nFieldTranslationState(
         ) {
             translatableResourcesByIds(first: 1, resourceIds: $resourceIds) {
                 nodes {
-                    resourceId
-                    translatableContent { key value digest locale }
-                    translations(locale: $locale) { key locale value }
+                    translatableContent { key digest }
+                    translations(locale: $locale) { key value }
                 }
             }
         }`,
-        {
-            variables: {
-                resourceIds: [entryId],
-                locale: FRAK_I18N_FR_LOCALE,
-            },
-        }
+        { resourceIds: [entryId], locale: FRAK_I18N_FR_LOCALE }
     );
-    const { data } = await response.json();
-    const node = data?.translatableResourcesByIds?.nodes?.[0];
+    if (!data) return null;
+    const node = data.translatableResourcesByIds?.nodes?.[0];
     const digestByKey = new Map<string, string>();
     const keysWithFr = new Set<string>();
     for (const c of node?.translatableContent ?? []) {
@@ -742,12 +761,18 @@ async function readFrakI18nFieldTranslationState(
 }
 
 async function registerFrakI18nFrTranslations(
-    { admin: { graphql } }: AuthenticatedContext,
+    context: AuthenticatedContext,
     entryId: string,
     translations: Array<{ key: string; value: string; digest: string }>
-): Promise<{ ok: boolean; errors: Array<{ message: string }> }> {
-    if (translations.length === 0) return { ok: true, errors: [] };
-    const response = await graphql(
+): Promise<boolean> {
+    if (translations.length === 0) return true;
+    const data = await runGraphQL<{
+        translationsRegister?: {
+            userErrors?: Array<{ message: string }>;
+        };
+    }>(
+        context.admin.graphql,
+        "fr register",
         `#graphql
         mutation RegisterFrakI18nFrTranslations(
             $resourceId: ID!
@@ -757,252 +782,72 @@ async function registerFrakI18nFrTranslations(
                 resourceId: $resourceId
                 translations: $translations
             ) {
-                translations { key value locale }
                 userErrors { field message code }
             }
         }`,
         {
-            variables: {
-                resourceId: entryId,
-                translations: translations.map((t) => ({
-                    locale: FRAK_I18N_FR_LOCALE,
-                    key: t.key,
-                    value: t.value,
-                    translatableContentDigest: t.digest,
-                })),
-            },
+            resourceId: entryId,
+            translations: translations.map((t) => ({
+                locale: FRAK_I18N_FR_LOCALE,
+                key: t.key,
+                value: t.value,
+                translatableContentDigest: t.digest,
+            })),
         }
     );
-    const body = (await response.json()) as GraphQLBody<{
-        translationsRegister?: {
-            userErrors?: Array<{ message: string }>;
-        };
-    }>;
-    if (body.errors?.length) {
-        console.error("[frakI18n] fr register top-level errors:", body.errors);
-        return {
-            ok: false,
-            errors: body.errors.map((e) => ({ message: e.message })),
-        };
+    if (!data) return false;
+    const errors = data.translationsRegister?.userErrors ?? [];
+    if (errors.length > 0) {
+        console.error("[frakI18n] fr translations rejected:", errors);
+        return false;
     }
-    const errors = body.data?.translationsRegister?.userErrors ?? [];
-    return { ok: errors.length === 0, errors };
+    return true;
 }
 
-export type FrakI18nSyncResult = {
-    definitionOk: boolean;
-    entryId: string | null;
-    frTranslationsRegistered: number;
-    errors: string[];
-};
-
 /**
- * Idempotent: ensure the `frak_i18n` metaobject definition exists,
- * upsert the singleton entry with bundled EN values, then register the
- * bundled FR translations for any field that doesn't already have one
- * (preserving merchant overrides).
+ * Idempotent: ensure the `frak_i18n` metaobject definition exists, create
+ * the singleton entry with bundled EN seeds when missing, then register
+ * the bundled FR translations for any field that doesn't already have one.
+ * Merchant EN edits are preserved (the entry is only seeded on first
+ * create); FR overrides are preserved via the `keysWithFr` check.
  *
- * Cached per shop for 30 minutes — but only on full success. Partial
- * failures stay retryable so a later loader can recover. Pass
- * `bypassCache=true` to force a re-run (used by the debug action).
+ * Cached per shop for 30 minutes — but only on full success, so partial
+ * failures stay retryable on the next loader call.
  */
 export async function ensureFrakI18nMetaobject(
-    context: AuthenticatedContext,
-    { bypassCache = false }: { bypassCache?: boolean } = {}
-): Promise<FrakI18nSyncResult> {
-    const shop = await shopInfo(context);
-    const cacheKey = shop.normalizedDomain;
-    const result: FrakI18nSyncResult = {
-        definitionOk: false,
-        entryId: null,
-        frTranslationsRegistered: 0,
-        errors: [],
-    };
-    if (!bypassCache && i18nMetaobjectSyncedShops.get(cacheKey)) {
-        result.definitionOk = true;
-        return result;
-    }
-
-    try {
-        const { ok } = await ensureFrakI18nDefinition(context);
-        result.definitionOk = ok;
-        if (!ok) {
-            result.errors.push("definition: create or read failed");
-            return result;
-        }
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error("[frakI18n] definition ensure threw:", error);
-        result.errors.push(`definition: ${message}`);
-        return result;
-    }
-
-    try {
-        const upsert = await upsertFrakI18nEntry(context);
-        result.entryId = upsert.id;
-        for (const msg of upsert.errorMessages) {
-            result.errors.push(`entry: ${msg}`);
-        }
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error("[frakI18n] entry upsert threw:", error);
-        result.errors.push(`entry: ${message}`);
-        return result;
-    }
-    if (!result.entryId) {
-        if (result.errors.length === 0) {
-            result.errors.push(
-                "entry: metaobjectUpsert returned no id (no userErrors surfaced)"
-            );
-        }
-        return result;
-    }
-
-    await syncFrakI18nFrTranslations(context, result);
-
-    if (result.errors.length === 0) {
-        i18nMetaobjectSyncedShops.set(cacheKey, true);
-    }
-    return result;
-}
-
-async function syncFrakI18nFrTranslations(
-    context: AuthenticatedContext,
-    result: FrakI18nSyncResult
-): Promise<void> {
-    if (!result.entryId) return;
-    try {
-        const state = await readFrakI18nFieldTranslationState(
-            context,
-            result.entryId
-        );
-        const missing = FRAK_I18N_FIELDS.flatMap((f) => {
-            if (!f.defaults.fr) return [];
-            if (state.keysWithFr.has(f.key)) return [];
-            const digest = state.digestByKey.get(f.key);
-            if (!digest) return [];
-            return [{ key: f.key, value: f.defaults.fr, digest }];
-        });
-        const { ok, errors } = await registerFrakI18nFrTranslations(
-            context,
-            result.entryId,
-            missing
-        );
-        if (ok) {
-            result.frTranslationsRegistered = missing.length;
-        } else {
-            console.error("[frakI18n] fr translations rejected:", errors);
-            result.errors.push(
-                `fr translations: ${errors.map((e) => e.message).join("; ")}`
-            );
-        }
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error("[frakI18n] fr translation step threw:", error);
-        result.errors.push(`fr translations: ${message}`);
-    }
-}
-
-/* -------------------------------------------------------------------------- */
-/*              Legacy i18n metafield cleanup (one-time migration)            */
-/* -------------------------------------------------------------------------- */
-
-const LEGACY_FRAK_I18N_METAFIELD_KEYS = new Set([
-    "banner_referral_title",
-    "banner_referral_description",
-    "banner_referral_cta",
-    "banner_inapp_title",
-    "banner_inapp_description",
-    "banner_inapp_cta",
-    "button_share_text",
-    "button_share_no_reward_text",
-    "post_purchase_message",
-    "post_purchase_description",
-    "post_purchase_cta_text",
-    "post_purchase_badge_text",
-]);
-
-const legacyI18nCleanupShops = new LRUCache<string, boolean>({
-    max: 512,
-    ttl: 24 * 60 * 60_000,
-});
-
-/**
- * Delete the legacy translatable text metafield definitions on the
- * shop's `frak` namespace, including any merchant-written values and
- * registered translations. Idempotent + LRU-cached 24h so it runs once
- * per shop per day.
- *
- * Other `frak.*` metafields (modal_i18n, appearance, merchant_id,
- * wallet_url, components_url, share_url, share_button_html) are
- * preserved — only the 12 keys in `LEGACY_FRAK_I18N_METAFIELD_KEYS`
- * are removed.
- */
-export async function cleanupLegacyFrakI18nMetafields(
     context: AuthenticatedContext
 ): Promise<void> {
     const shop = await shopInfo(context);
     const cacheKey = shop.normalizedDomain;
-    if (legacyI18nCleanupShops.get(cacheKey)) return;
+    if (i18nMetaobjectSyncedShops.get(cacheKey)) return;
 
-    const { admin } = context;
-    let definitionsToDelete: Array<{ id: string; key: string }>;
-    try {
-        const response = await admin.graphql(
-            `#graphql
-            query ListLegacyFrakI18nDefinitions($namespace: String!) {
-                metafieldDefinitions(
-                    namespace: $namespace
-                    ownerType: SHOP
-                    first: 100
-                ) {
-                    nodes { id key }
-                }
-            }`,
-            { variables: { namespace: FRAK_NAMESPACE } }
-        );
-        const { data } = await response.json();
-        const nodes: Array<{ id: string; key: string }> =
-            data?.metafieldDefinitions?.nodes ?? [];
-        definitionsToDelete = nodes.filter((d) =>
-            LEGACY_FRAK_I18N_METAFIELD_KEYS.has(d.key)
-        );
-    } catch (error) {
-        console.error("[frakI18n] legacy cleanup list failed:", error);
-        return;
+    const state = await readFrakI18nState(context);
+    if (!state) return;
+    if (!state.definitionExists) {
+        const created = await createFrakI18nDefinition(context);
+        if (!created) return;
     }
+    const entryId = state.entryId ?? (await upsertFrakI18nEntry(context));
+    if (!entryId) return;
 
-    if (definitionsToDelete.length === 0) {
-        legacyI18nCleanupShops.set(cacheKey, true);
-        return;
-    }
+    const frOk = await syncFrakI18nFrTranslations(context, entryId);
+    if (frOk) i18nMetaobjectSyncedShops.set(cacheKey, true);
+}
 
-    const results = await Promise.allSettled(
-        definitionsToDelete.map((def) =>
-            admin.graphql(
-                `#graphql
-                mutation DeleteLegacyFrakI18nDefinition($id: ID!) {
-                    metafieldDefinitionDelete(
-                        id: $id
-                        deleteAllAssociatedMetafields: true
-                    ) {
-                        deletedDefinitionId
-                        userErrors { field message code }
-                    }
-                }`,
-                { variables: { id: def.id } }
-            )
-        )
-    );
-    for (const [i, result] of results.entries()) {
-        if (result.status === "rejected") {
-            console.error(
-                `[frakI18n] legacy def delete failed for ${definitionsToDelete[i].key}:`,
-                result.reason
-            );
-        }
-    }
-    legacyI18nCleanupShops.set(cacheKey, true);
+async function syncFrakI18nFrTranslations(
+    context: AuthenticatedContext,
+    entryId: string
+): Promise<boolean> {
+    const state = await readFrakI18nFieldTranslationState(context, entryId);
+    if (!state) return false;
+    const missing = FRAK_I18N_FIELDS.flatMap((f) => {
+        if (!f.defaults.fr) return [];
+        if (state.keysWithFr.has(f.key)) return [];
+        const digest = state.digestByKey.get(f.key);
+        if (!digest) return [];
+        return [{ key: f.key, value: f.defaults.fr, digest }];
+    });
+    return registerFrakI18nFrTranslations(context, entryId, missing);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/shopify/extensions/checkout-post-purchase/locales/en.default.json
+++ b/apps/shopify/extensions/checkout-post-purchase/locales/en.default.json
@@ -1,0 +1,5 @@
+{
+    "message": "Earn rewards through sharing",
+    "description": "If they buy, they earn... and so do you!",
+    "cta": "Share & earn"
+}

--- a/apps/shopify/extensions/checkout-post-purchase/locales/fr.json
+++ b/apps/shopify/extensions/checkout-post-purchase/locales/fr.json
@@ -1,0 +1,5 @@
+{
+    "message": "Gagnez des récompenses en partageant",
+    "description": "S'ils achètent, ils gagnent… et vous aussi !",
+    "cta": "Partager & gagner"
+}

--- a/apps/shopify/extensions/checkout-post-purchase/shopify.d.ts
+++ b/apps/shopify/extensions/checkout-post-purchase/shopify.d.ts
@@ -13,6 +13,14 @@ declare module './src/OrderStatus.tsx' {
 }
 
 //@ts-ignore
+declare module './src/frakI18n.ts' {
+  const shopify:
+    | import('@shopify/ui-extensions/purchase.thank-you.block.render').Api
+    | import('@shopify/ui-extensions/customer-account.order-status.block.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}
+
+//@ts-ignore
 declare module './src/frakMetafields.ts' {
   const shopify:
     | import('@shopify/ui-extensions/purchase.thank-you.block.render').Api

--- a/apps/shopify/extensions/checkout-post-purchase/shopify.extension.toml
+++ b/apps/shopify/extensions/checkout-post-purchase/shopify.extension.toml
@@ -30,6 +30,25 @@ key = "wallet_url"
 namespace = "frak"
 key = "appearance"
 
+# Translatable text metafields managed via Translate & Adapt. Read here so
+# the post-purchase card can render the buyer's locale automatically when
+# no per-extension setting overrides it.
+[[extensions.metafields]]
+namespace = "frak"
+key = "post_purchase_message"
+
+[[extensions.metafields]]
+namespace = "frak"
+key = "post_purchase_description"
+
+[[extensions.metafields]]
+namespace = "frak"
+key = "post_purchase_cta_text"
+
+[[extensions.metafields]]
+namespace = "frak"
+key = "post_purchase_badge_text"
+
 # Merchant-configurable text settings
 [extensions.settings]
 

--- a/apps/shopify/extensions/checkout-post-purchase/shopify.extension.toml
+++ b/apps/shopify/extensions/checkout-post-purchase/shopify.extension.toml
@@ -6,6 +6,13 @@ type = "ui_extension"
 name = "Frak Post Purchase"
 handle = "checkout-post-purchase"
 
+  [extensions.capabilities]
+  # Required to call shopify.query() against the Storefront API. The
+  # extension queries the `frak_i18n` metaobject for per-locale text
+  # overrides (post_purchase_message / _description / _cta_text /
+  # _badge_text) — Translate & Adapt edits propagate automatically.
+  api_access = true
+
 # Thank You page — shown immediately after checkout completes
 [[extensions.targeting]]
 target = "purchase.thank-you.block.render"
@@ -29,25 +36,6 @@ key = "wallet_url"
 [[extensions.metafields]]
 namespace = "frak"
 key = "appearance"
-
-# Translatable text metafields managed via Translate & Adapt. Read here so
-# the post-purchase card can render the buyer's locale automatically when
-# no per-extension setting overrides it.
-[[extensions.metafields]]
-namespace = "frak"
-key = "post_purchase_message"
-
-[[extensions.metafields]]
-namespace = "frak"
-key = "post_purchase_description"
-
-[[extensions.metafields]]
-namespace = "frak"
-key = "post_purchase_cta_text"
-
-[[extensions.metafields]]
-namespace = "frak"
-key = "post_purchase_badge_text"
 
 # Merchant-configurable text settings
 [extensions.settings]

--- a/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
@@ -4,13 +4,18 @@ import {
     useAttributeValues,
     useCartLines,
     useExtensionEditor,
+    useLanguage,
     useSettings,
     useShop,
     useSubscription,
     useTranslate,
 } from "@shopify/ui-extensions/customer-account/preact";
 import { render } from "preact";
-import { useMemo } from "preact/hooks";
+import { useEffect, useMemo, useState } from "preact/hooks";
+import {
+    fetchPostPurchaseTextOverrides,
+    type PostPurchaseTextOverrides,
+} from "./frakI18n";
 import { extractFrakConfig } from "./frakMetafields";
 import { PostPurchaseCard } from "./PostPurchaseCard";
 
@@ -21,6 +26,7 @@ function OrderStatusExtension() {
     const cartLines = useCartLines();
     const editor = useExtensionEditor();
     const t = useTranslate();
+    const language = useLanguage();
     // Subscribe to the checkout token — correlates with the web pixel payload
     // and gives the backend an identifier for the purchase.
     const api = useApi<"customer-account.order-status.block.render">();
@@ -32,6 +38,25 @@ function OrderStatusExtension() {
         () => extractFrakConfig(frakMetafields),
         [frakMetafields]
     );
+
+    // Per-locale text overrides come from the frak_i18n metaobject via
+    // the Storefront API — useAppMetafields can't resolve metaobject
+    // references, so we query directly. The Storefront API resolves the
+    // buyer's locale via @inContext (language code passed in the query).
+    const [textOverrides, setTextOverrides] = useState<
+        PostPurchaseTextOverrides | undefined
+    >();
+    useEffect(() => {
+        let cancelled = false;
+        fetchPostPurchaseTextOverrides(api.query, language.isoCode)
+            .then((overrides) => {
+                if (!cancelled) setTextOverrides(overrides);
+            })
+            .catch(() => {});
+        return () => {
+            cancelled = true;
+        };
+    }, [api.query, language.isoCode]);
 
     // Map cart lines to product info for the sharing page
     const products = useMemo(
@@ -47,7 +72,7 @@ function OrderStatusExtension() {
     return (
         <PostPurchaseCard
             settings={settings}
-            textOverrides={frakConfig.text}
+            textOverrides={textOverrides}
             defaults={{
                 message: t("message"),
                 description: t("description"),

--- a/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
@@ -7,6 +7,7 @@ import {
     useSettings,
     useShop,
     useSubscription,
+    useTranslate,
 } from "@shopify/ui-extensions/customer-account/preact";
 import { render } from "preact";
 import { useMemo } from "preact/hooks";
@@ -19,6 +20,7 @@ function OrderStatusExtension() {
     const shop = useShop();
     const cartLines = useCartLines();
     const editor = useExtensionEditor();
+    const t = useTranslate();
     // Subscribe to the checkout token — correlates with the web pixel payload
     // and gives the backend an identifier for the purchase.
     const api = useApi<"customer-account.order-status.block.render">();
@@ -46,6 +48,11 @@ function OrderStatusExtension() {
         <PostPurchaseCard
             settings={settings}
             textOverrides={frakConfig.text}
+            defaults={{
+                message: t("message"),
+                description: t("description"),
+                cta: t("cta"),
+            }}
             clientId={clientId}
             shopName={shop.name}
             storefrontUrl={shop.storefrontUrl}

--- a/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
@@ -45,6 +45,7 @@ function OrderStatusExtension() {
     return (
         <PostPurchaseCard
             settings={settings}
+            textOverrides={frakConfig.text}
             clientId={clientId}
             shopName={shop.name}
             storefrontUrl={shop.storefrontUrl}

--- a/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/OrderStatus.tsx
@@ -11,11 +11,8 @@ import {
     useTranslate,
 } from "@shopify/ui-extensions/customer-account/preact";
 import { render } from "preact";
-import { useEffect, useMemo, useState } from "preact/hooks";
-import {
-    fetchPostPurchaseTextOverrides,
-    type PostPurchaseTextOverrides,
-} from "./frakI18n";
+import { useMemo } from "preact/hooks";
+import { usePostPurchaseTextOverrides } from "./frakI18n";
 import { extractFrakConfig } from "./frakMetafields";
 import { PostPurchaseCard } from "./PostPurchaseCard";
 
@@ -43,20 +40,10 @@ function OrderStatusExtension() {
     // the Storefront API — useAppMetafields can't resolve metaobject
     // references, so we query directly. The Storefront API resolves the
     // buyer's locale via @inContext (language code passed in the query).
-    const [textOverrides, setTextOverrides] = useState<
-        PostPurchaseTextOverrides | undefined
-    >();
-    useEffect(() => {
-        let cancelled = false;
-        fetchPostPurchaseTextOverrides(api.query, language.isoCode)
-            .then((overrides) => {
-                if (!cancelled) setTextOverrides(overrides);
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [api.query, language.isoCode]);
+    const textOverrides = usePostPurchaseTextOverrides(
+        api.query,
+        language.isoCode
+    );
 
     // Map cart lines to product info for the sharing page
     const products = useMemo(

--- a/apps/shopify/extensions/checkout-post-purchase/src/PostPurchaseCard.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/PostPurchaseCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "preact/hooks";
+import type { PostPurchaseTextOverrides } from "./frakI18n";
 
 const DEFAULT_WALLET_URL = "https://wallet.frak.id";
 
@@ -19,18 +20,6 @@ type PostPurchaseSettings = {
     cta_text?: string;
     badge_text?: string;
     image_url?: string;
-};
-
-/**
- * Translatable text overrides read from shop metafields. Each value is
- * the buyer-locale translation when one exists in Translate & Adapt;
- * `undefined` otherwise.
- */
-export type PostPurchaseTextOverrides = {
-    message?: string;
-    description?: string;
-    ctaText?: string;
-    badgeText?: string;
 };
 
 /**
@@ -131,9 +120,9 @@ export function PostPurchaseCard({
 }: {
     settings: Partial<PostPurchaseSettings>;
     /**
-     * Translatable text overrides from `frak.post_purchase_*` metafields.
-     * Resolved per buyer locale via Translate & Adapt. Lower priority than
-     * per-extension `settings`, higher than `defaults`.
+     * Per-locale text overrides fetched from the `frak_i18n` metaobject
+     * via the Storefront API. Lower priority than per-extension
+     * `settings`, higher than `defaults`.
      */
     textOverrides?: PostPurchaseTextOverrides;
     /** Locale-resolved fallback text from the extension's `locales/` files. */

--- a/apps/shopify/extensions/checkout-post-purchase/src/PostPurchaseCard.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/PostPurchaseCard.tsx
@@ -24,6 +24,18 @@ type PostPurchaseSettings = {
     image_url?: string;
 };
 
+/**
+ * Translatable text overrides read from shop metafields. Each value is
+ * the buyer-locale translation when one exists in Translate & Adapt;
+ * `undefined` otherwise.
+ */
+export type PostPurchaseTextOverrides = {
+    message?: string;
+    description?: string;
+    ctaText?: string;
+    badgeText?: string;
+};
+
 export type ProductInfo = {
     title: string;
     imageUrl?: string;
@@ -96,6 +108,7 @@ function constructSharingUrl({
  */
 export function PostPurchaseCard({
     settings,
+    textOverrides,
     clientId,
     shopName,
     storefrontUrl,
@@ -108,6 +121,12 @@ export function PostPurchaseCard({
     isEditor,
 }: {
     settings: Partial<PostPurchaseSettings>;
+    /**
+     * Translatable text overrides from `frak.post_purchase_*` metafields.
+     * Resolved per buyer locale via Translate & Adapt. Lower priority than
+     * per-extension `settings`, higher than the hardcoded defaults.
+     */
+    textOverrides?: PostPurchaseTextOverrides;
     clientId?: string;
     shopName?: string;
     /** Shop storefront URL — fallback when sharing_url setting is empty */
@@ -128,10 +147,14 @@ export function PostPurchaseCard({
 }) {
     const sharingUrl = settings.sharing_url || storefrontUrl;
     const resolvedWalletUrl = walletUrl || DEFAULT_WALLET_URL;
-    const message = settings.message || DEFAULT_MESSAGE;
-    const description = settings.description || DEFAULT_DESCRIPTION;
-    const ctaText = settings.cta_text || DEFAULT_CTA;
-    const badgeText = settings.badge_text;
+    const message =
+        settings.message || textOverrides?.message || DEFAULT_MESSAGE;
+    const description =
+        settings.description ||
+        textOverrides?.description ||
+        DEFAULT_DESCRIPTION;
+    const ctaText = settings.cta_text || textOverrides?.ctaText || DEFAULT_CTA;
+    const badgeText = settings.badge_text || textOverrides?.badgeText;
     const imageUrl = settings.image_url;
 
     // Build external sharing page URL with all params

--- a/apps/shopify/extensions/checkout-post-purchase/src/PostPurchaseCard.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/PostPurchaseCard.tsx
@@ -1,8 +1,5 @@
 import { useMemo } from "preact/hooks";
 
-const DEFAULT_MESSAGE = "Earn rewards through sharing";
-const DEFAULT_DESCRIPTION = "If they buy, they earn... and so do you!";
-const DEFAULT_CTA = "Share & earn";
 const DEFAULT_WALLET_URL = "https://wallet.frak.id";
 
 const GIFT_SVG_DATA_URI =
@@ -34,6 +31,17 @@ export type PostPurchaseTextOverrides = {
     description?: string;
     ctaText?: string;
     badgeText?: string;
+};
+
+/**
+ * Locale-resolved defaults produced by the entrypoint via `useTranslate`,
+ * using the extension's `locales/` JSON files. Always populated — used
+ * when neither `settings` nor `textOverrides` provide a value.
+ */
+export type PostPurchaseTextDefaults = {
+    message: string;
+    description: string;
+    cta: string;
 };
 
 export type ProductInfo = {
@@ -109,6 +117,7 @@ function constructSharingUrl({
 export function PostPurchaseCard({
     settings,
     textOverrides,
+    defaults,
     clientId,
     shopName,
     storefrontUrl,
@@ -124,9 +133,11 @@ export function PostPurchaseCard({
     /**
      * Translatable text overrides from `frak.post_purchase_*` metafields.
      * Resolved per buyer locale via Translate & Adapt. Lower priority than
-     * per-extension `settings`, higher than the hardcoded defaults.
+     * per-extension `settings`, higher than `defaults`.
      */
     textOverrides?: PostPurchaseTextOverrides;
+    /** Locale-resolved fallback text from the extension's `locales/` files. */
+    defaults: PostPurchaseTextDefaults;
     clientId?: string;
     shopName?: string;
     /** Shop storefront URL — fallback when sharing_url setting is empty */
@@ -148,12 +159,12 @@ export function PostPurchaseCard({
     const sharingUrl = settings.sharing_url || storefrontUrl;
     const resolvedWalletUrl = walletUrl || DEFAULT_WALLET_URL;
     const message =
-        settings.message || textOverrides?.message || DEFAULT_MESSAGE;
+        settings.message || textOverrides?.message || defaults.message;
     const description =
         settings.description ||
         textOverrides?.description ||
-        DEFAULT_DESCRIPTION;
-    const ctaText = settings.cta_text || textOverrides?.ctaText || DEFAULT_CTA;
+        defaults.description;
+    const ctaText = settings.cta_text || textOverrides?.ctaText || defaults.cta;
     const badgeText = settings.badge_text || textOverrides?.badgeText;
     const imageUrl = settings.image_url;
 

--- a/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
@@ -41,6 +41,7 @@ function ThankYouExtension() {
     return (
         <PostPurchaseCard
             settings={settings}
+            textOverrides={frakConfig.text}
             clientId={clientId}
             shopName={shop.name}
             storefrontUrl={shop.storefrontUrl}

--- a/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
@@ -11,11 +11,8 @@ import {
     useTranslate,
 } from "@shopify/ui-extensions/checkout/preact";
 import { render } from "preact";
-import { useEffect, useMemo, useState } from "preact/hooks";
-import {
-    fetchPostPurchaseTextOverrides,
-    type PostPurchaseTextOverrides,
-} from "./frakI18n";
+import { useMemo } from "preact/hooks";
+import { usePostPurchaseTextOverrides } from "./frakI18n";
 import { extractFrakConfig } from "./frakMetafields";
 import { PostPurchaseCard } from "./PostPurchaseCard";
 
@@ -41,20 +38,7 @@ function ThankYouExtension() {
     // the Storefront API — useAppMetafields can't resolve metaobject
     // references, so we query directly. The Storefront API resolves the
     // buyer's locale via @inContext (language code passed in the query).
-    const [textOverrides, setTextOverrides] = useState<
-        PostPurchaseTextOverrides | undefined
-    >();
-    useEffect(() => {
-        let cancelled = false;
-        fetchPostPurchaseTextOverrides(query, language.isoCode)
-            .then((overrides) => {
-                if (!cancelled) setTextOverrides(overrides);
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [query, language.isoCode]);
+    const textOverrides = usePostPurchaseTextOverrides(query, language.isoCode);
 
     // Map cart lines to product info for the sharing page
     const products = useMemo(

--- a/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
@@ -6,6 +6,7 @@ import {
     useExtensionEditor,
     useSettings,
     useShop,
+    useTranslate,
 } from "@shopify/ui-extensions/checkout/preact";
 import { render } from "preact";
 import { useMemo } from "preact/hooks";
@@ -19,6 +20,7 @@ function ThankYouExtension() {
     const cartLines = useCartLines();
     const checkoutToken = useCheckoutToken();
     const editor = useExtensionEditor();
+    const t = useTranslate();
 
     // Read merchantId, walletUrl, logoUrl from shop metafields
     const frakMetafields = useAppMetafields({ namespace: "frak" });
@@ -42,6 +44,11 @@ function ThankYouExtension() {
         <PostPurchaseCard
             settings={settings}
             textOverrides={frakConfig.text}
+            defaults={{
+                message: t("message"),
+                description: t("description"),
+                cta: t("cta"),
+            }}
             clientId={clientId}
             shopName={shop.name}
             storefrontUrl={shop.storefrontUrl}

--- a/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
+++ b/apps/shopify/extensions/checkout-post-purchase/src/ThankYou.tsx
@@ -1,15 +1,21 @@
 import {
+    useApi,
     useAppMetafields,
     useAttributeValues,
     useCartLines,
     useCheckoutToken,
     useExtensionEditor,
+    useLanguage,
     useSettings,
     useShop,
     useTranslate,
 } from "@shopify/ui-extensions/checkout/preact";
 import { render } from "preact";
-import { useMemo } from "preact/hooks";
+import { useEffect, useMemo, useState } from "preact/hooks";
+import {
+    fetchPostPurchaseTextOverrides,
+    type PostPurchaseTextOverrides,
+} from "./frakI18n";
 import { extractFrakConfig } from "./frakMetafields";
 import { PostPurchaseCard } from "./PostPurchaseCard";
 
@@ -21,6 +27,8 @@ function ThankYouExtension() {
     const checkoutToken = useCheckoutToken();
     const editor = useExtensionEditor();
     const t = useTranslate();
+    const language = useLanguage();
+    const { query } = useApi<"purchase.thank-you.block.render">();
 
     // Read merchantId, walletUrl, logoUrl from shop metafields
     const frakMetafields = useAppMetafields({ namespace: "frak" });
@@ -28,6 +36,25 @@ function ThankYouExtension() {
         () => extractFrakConfig(frakMetafields),
         [frakMetafields]
     );
+
+    // Per-locale text overrides come from the frak_i18n metaobject via
+    // the Storefront API — useAppMetafields can't resolve metaobject
+    // references, so we query directly. The Storefront API resolves the
+    // buyer's locale via @inContext (language code passed in the query).
+    const [textOverrides, setTextOverrides] = useState<
+        PostPurchaseTextOverrides | undefined
+    >();
+    useEffect(() => {
+        let cancelled = false;
+        fetchPostPurchaseTextOverrides(query, language.isoCode)
+            .then((overrides) => {
+                if (!cancelled) setTextOverrides(overrides);
+            })
+            .catch(() => {});
+        return () => {
+            cancelled = true;
+        };
+    }, [query, language.isoCode]);
 
     // Map cart lines to product info for the sharing page
     const products = useMemo(
@@ -43,7 +70,7 @@ function ThankYouExtension() {
     return (
         <PostPurchaseCard
             settings={settings}
-            textOverrides={frakConfig.text}
+            textOverrides={textOverrides}
             defaults={{
                 message: t("message"),
                 description: t("description"),

--- a/apps/shopify/extensions/checkout-post-purchase/src/frakI18n.ts
+++ b/apps/shopify/extensions/checkout-post-purchase/src/frakI18n.ts
@@ -7,6 +7,8 @@
  * `@inContext` directive.
  */
 
+import { useEffect, useState } from "preact/hooks";
+
 export type PostPurchaseTextOverrides = {
     message?: string;
     description?: string;
@@ -44,7 +46,16 @@ function nonEmpty(value: string | null | undefined): string | undefined {
     return value && value.length > 0 ? value : undefined;
 }
 
-export async function fetchPostPurchaseTextOverrides(
+/**
+ * Convert a BCP-47 ISO code (`fr`, `fr-CA`) to Shopify's `LanguageCode`
+ * GraphQL enum (`FR`, `FR_CA`). `useLanguage().isoCode` returns BCP-47
+ * with `-` separators; the GraphQL enum uses `_`.
+ */
+function toLanguageCode(isoCode: string): string {
+    return isoCode.replace("-", "_").toUpperCase();
+}
+
+async function fetchPostPurchaseTextOverrides(
     query: StorefrontQuery,
     languageIsoCode: string
 ): Promise<PostPurchaseTextOverrides> {
@@ -52,7 +63,7 @@ export async function fetchPostPurchaseTextOverrides(
         variables: {
             type: FRAK_I18N_METAOBJECT_TYPE,
             handle: FRAK_I18N_SINGLETON_HANDLE,
-            language: languageIsoCode.toUpperCase(),
+            language: toLanguageCode(languageIsoCode),
         },
     });
     const fields = response?.data?.metaobject?.fields;
@@ -65,4 +76,28 @@ export async function fetchPostPurchaseTextOverrides(
         ctaText: nonEmpty(map.get("post_purchase_cta_text")),
         badgeText: nonEmpty(map.get("post_purchase_badge_text")),
     };
+}
+
+/**
+ * Fetch the post-purchase text overrides for the buyer's locale once on
+ * mount (and whenever the language switches). Shared by the Thank You
+ * and Order Status surfaces.
+ */
+export function usePostPurchaseTextOverrides(
+    query: StorefrontQuery,
+    languageIsoCode: string
+): PostPurchaseTextOverrides | undefined {
+    const [overrides, setOverrides] = useState<PostPurchaseTextOverrides>();
+    useEffect(() => {
+        let cancelled = false;
+        fetchPostPurchaseTextOverrides(query, languageIsoCode)
+            .then((next) => {
+                if (!cancelled) setOverrides(next);
+            })
+            .catch(() => {});
+        return () => {
+            cancelled = true;
+        };
+    }, [query, languageIsoCode]);
+    return overrides;
 }

--- a/apps/shopify/extensions/checkout-post-purchase/src/frakI18n.ts
+++ b/apps/shopify/extensions/checkout-post-purchase/src/frakI18n.ts
@@ -1,0 +1,68 @@
+/**
+ * Per-locale text overrides for the post-purchase card. Fetched from the
+ * `frak_i18n` metaobject (singleton entry with handle `default`) via the
+ * Storefront API. Translations registered against the metaobject by
+ * Shopify's Translate & Adapt app surface here automatically — the
+ * Storefront API resolves the buyer's locale via the query's
+ * `@inContext` directive.
+ */
+
+export type PostPurchaseTextOverrides = {
+    message?: string;
+    description?: string;
+    ctaText?: string;
+    badgeText?: string;
+};
+
+const FRAK_I18N_METAOBJECT_TYPE = "frak_i18n";
+const FRAK_I18N_SINGLETON_HANDLE = "default";
+
+const FETCH_QUERY = `#graphql
+  query FetchFrakI18n(
+    $type: String!
+    $handle: String!
+    $language: LanguageCode!
+  ) @inContext(language: $language) {
+    metaobject(handle: { type: $type, handle: $handle }) {
+      fields { key value }
+    }
+  }
+`;
+
+type FetchFrakI18nData = {
+    metaobject?: {
+        fields?: Array<{ key: string; value: string | null }>;
+    } | null;
+};
+
+type StorefrontQuery = <Data>(
+    query: string,
+    options?: { variables?: Record<string, unknown> }
+) => Promise<{ data?: Data; errors?: Array<{ message: string }> }>;
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+    return value && value.length > 0 ? value : undefined;
+}
+
+export async function fetchPostPurchaseTextOverrides(
+    query: StorefrontQuery,
+    languageIsoCode: string
+): Promise<PostPurchaseTextOverrides> {
+    const response = await query<FetchFrakI18nData>(FETCH_QUERY, {
+        variables: {
+            type: FRAK_I18N_METAOBJECT_TYPE,
+            handle: FRAK_I18N_SINGLETON_HANDLE,
+            language: languageIsoCode.toUpperCase(),
+        },
+    });
+    const fields = response?.data?.metaobject?.fields;
+    if (!fields) return {};
+    const map = new Map<string, string | null>();
+    for (const f of fields) map.set(f.key, f.value);
+    return {
+        message: nonEmpty(map.get("post_purchase_message")),
+        description: nonEmpty(map.get("post_purchase_description")),
+        ctaText: nonEmpty(map.get("post_purchase_cta_text")),
+        badgeText: nonEmpty(map.get("post_purchase_badge_text")),
+    };
+}

--- a/apps/shopify/extensions/checkout-post-purchase/src/frakMetafields.ts
+++ b/apps/shopify/extensions/checkout-post-purchase/src/frakMetafields.ts
@@ -6,28 +6,19 @@
  *  - frak.wallet_url   → wallet base URL (JSON-encoded string)
  *  - frak.appearance   → { logoUrl?: string } (JSON object)
  *
- * Plus translatable text metafields managed via Shopify's Translate &
- * Adapt app. These are read here so the buyer's checkout locale picks
- * the right translation automatically:
- *  - frak.post_purchase_message
- *  - frak.post_purchase_description
- *  - frak.post_purchase_cta_text
- *  - frak.post_purchase_badge_text
+ * Per-locale text overrides live on the `frak_i18n` metaobject and are
+ * fetched separately via `fetchPostPurchaseTextOverrides` in
+ * `frakI18n.ts` — `useAppMetafields` cannot resolve metaobject
+ * references, so a Storefront API query is required.
  *
  * All JSON values are stored via JSON.stringify(), so we JSON.parse() on
- * read. Text-type metafields come through as plain strings.
+ * read.
  */
 
 type FrakConfig = {
     merchantId?: string;
     walletUrl?: string;
     logoUrl?: string;
-    text: {
-        message?: string;
-        description?: string;
-        ctaText?: string;
-        badgeText?: string;
-    };
 };
 
 function parseJsonValue<T>(raw: string | number | boolean): T | string {
@@ -40,17 +31,6 @@ function parseJsonValue<T>(raw: string | number | boolean): T | string {
 }
 
 /**
- * Translate & Adapt may return the same translatable text value as either
- * a plain string or a JSON-encoded string depending on the surface. Strip
- * either shape down to a non-empty string or `undefined`.
- */
-function readTextValue(raw: string | number | boolean): string | undefined {
-    const parsed = parseJsonValue<unknown>(raw);
-    const value = typeof parsed === "string" ? parsed : String(parsed);
-    return value.length > 0 ? value : undefined;
-}
-
-/**
  * Extract Frak metafields needed by the post-purchase card.
  *
  * Works with both checkout and customer-account surfaces — the MetafieldEntry
@@ -59,37 +39,22 @@ function readTextValue(raw: string | number | boolean): string | undefined {
 export function extractFrakConfig(
     entries: { metafield: { key: string; value: string | number | boolean } }[]
 ): FrakConfig {
-    return entries.reduce<FrakConfig>(
-        (config, entry) => {
-            const { key, value } = entry.metafield;
-            switch (key) {
-                case "merchant_id":
-                    config.merchantId = parseJsonValue<string>(value) as string;
-                    break;
-                case "wallet_url":
-                    config.walletUrl = parseJsonValue<string>(value) as string;
-                    break;
-                case "appearance": {
-                    const parsed = parseJsonValue<{ logoUrl?: string }>(value);
-                    config.logoUrl =
-                        typeof parsed === "object" ? parsed.logoUrl : undefined;
-                    break;
-                }
-                case "post_purchase_message":
-                    config.text.message = readTextValue(value);
-                    break;
-                case "post_purchase_description":
-                    config.text.description = readTextValue(value);
-                    break;
-                case "post_purchase_cta_text":
-                    config.text.ctaText = readTextValue(value);
-                    break;
-                case "post_purchase_badge_text":
-                    config.text.badgeText = readTextValue(value);
-                    break;
+    return entries.reduce<FrakConfig>((config, entry) => {
+        const { key, value } = entry.metafield;
+        switch (key) {
+            case "merchant_id":
+                config.merchantId = parseJsonValue<string>(value) as string;
+                break;
+            case "wallet_url":
+                config.walletUrl = parseJsonValue<string>(value) as string;
+                break;
+            case "appearance": {
+                const parsed = parseJsonValue<{ logoUrl?: string }>(value);
+                config.logoUrl =
+                    typeof parsed === "object" ? parsed.logoUrl : undefined;
+                break;
             }
-            return config;
-        },
-        { text: {} }
-    );
+        }
+        return config;
+    }, {});
 }

--- a/apps/shopify/extensions/checkout-post-purchase/src/frakMetafields.ts
+++ b/apps/shopify/extensions/checkout-post-purchase/src/frakMetafields.ts
@@ -6,13 +6,28 @@
  *  - frak.wallet_url   → wallet base URL (JSON-encoded string)
  *  - frak.appearance   → { logoUrl?: string } (JSON object)
  *
- * All values are stored via JSON.stringify(), so we JSON.parse() on read.
+ * Plus translatable text metafields managed via Shopify's Translate &
+ * Adapt app. These are read here so the buyer's checkout locale picks
+ * the right translation automatically:
+ *  - frak.post_purchase_message
+ *  - frak.post_purchase_description
+ *  - frak.post_purchase_cta_text
+ *  - frak.post_purchase_badge_text
+ *
+ * All JSON values are stored via JSON.stringify(), so we JSON.parse() on
+ * read. Text-type metafields come through as plain strings.
  */
 
 type FrakConfig = {
     merchantId?: string;
     walletUrl?: string;
     logoUrl?: string;
+    text: {
+        message?: string;
+        description?: string;
+        ctaText?: string;
+        badgeText?: string;
+    };
 };
 
 function parseJsonValue<T>(raw: string | number | boolean): T | string {
@@ -25,7 +40,18 @@ function parseJsonValue<T>(raw: string | number | boolean): T | string {
 }
 
 /**
- * Extract merchantId, walletUrl, and logoUrl from app metafield entries.
+ * Translate & Adapt may return the same translatable text value as either
+ * a plain string or a JSON-encoded string depending on the surface. Strip
+ * either shape down to a non-empty string or `undefined`.
+ */
+function readTextValue(raw: string | number | boolean): string | undefined {
+    const parsed = parseJsonValue<unknown>(raw);
+    const value = typeof parsed === "string" ? parsed : String(parsed);
+    return value.length > 0 ? value : undefined;
+}
+
+/**
+ * Extract Frak metafields needed by the post-purchase card.
  *
  * Works with both checkout and customer-account surfaces — the MetafieldEntry
  * shape is compatible with AppMetafieldEntry from either import path.
@@ -33,22 +59,37 @@ function parseJsonValue<T>(raw: string | number | boolean): T | string {
 export function extractFrakConfig(
     entries: { metafield: { key: string; value: string | number | boolean } }[]
 ): FrakConfig {
-    return entries.reduce<FrakConfig>((config, entry) => {
-        const { key, value } = entry.metafield;
-        switch (key) {
-            case "merchant_id":
-                config.merchantId = parseJsonValue<string>(value);
-                break;
-            case "wallet_url":
-                config.walletUrl = parseJsonValue<string>(value);
-                break;
-            case "appearance": {
-                const parsed = parseJsonValue<{ logoUrl?: string }>(value);
-                config.logoUrl =
-                    typeof parsed === "object" ? parsed.logoUrl : undefined;
-                break;
+    return entries.reduce<FrakConfig>(
+        (config, entry) => {
+            const { key, value } = entry.metafield;
+            switch (key) {
+                case "merchant_id":
+                    config.merchantId = parseJsonValue<string>(value) as string;
+                    break;
+                case "wallet_url":
+                    config.walletUrl = parseJsonValue<string>(value) as string;
+                    break;
+                case "appearance": {
+                    const parsed = parseJsonValue<{ logoUrl?: string }>(value);
+                    config.logoUrl =
+                        typeof parsed === "object" ? parsed.logoUrl : undefined;
+                    break;
+                }
+                case "post_purchase_message":
+                    config.text.message = readTextValue(value);
+                    break;
+                case "post_purchase_description":
+                    config.text.description = readTextValue(value);
+                    break;
+                case "post_purchase_cta_text":
+                    config.text.ctaText = readTextValue(value);
+                    break;
+                case "post_purchase_badge_text":
+                    config.text.badgeText = readTextValue(value);
+                    break;
             }
-        }
-        return config;
-    }, {});
+            return config;
+        },
+        { text: {} }
+    );
 }

--- a/apps/shopify/extensions/theme-components/blocks/banner.liquid
+++ b/apps/shopify/extensions/theme-components/blocks/banner.liquid
@@ -6,16 +6,24 @@
 {% comment %}
   Resolution chain per text: per-block setting → translatable metaobject
   field (`frak_i18n` entry with handle `default`, managed via Translate &
-  Adapt) → storefront-locale fallback (`| t`). Skipping the attribute
-  entirely lets the SDK fall back to its built-ins.
+  Adapt) → storefront-locale fallback. The `| t` filter is applied to the
+  locale-key fallback BEFORE the `default` cascade — otherwise Liquid
+  pipes the resolved value (merchant text or metaobject field) through
+  `| t` and emits "Translation missing: {locale}. <text>".
 {% endcomment %}
 {% assign frak_i18n = shop.metaobjects.frak_i18n.default %}
-{% assign referral_title = block.settings.referral_title | default: frak_i18n.banner_referral_title | default: 'banner.referral.title' | t %}
-{% assign referral_description = block.settings.referral_description | default: frak_i18n.banner_referral_description | default: 'banner.referral.description' | t %}
-{% assign referral_cta = block.settings.referral_cta | default: frak_i18n.banner_referral_cta | default: 'banner.referral.cta' | t %}
-{% assign inapp_title = block.settings.inapp_title | default: frak_i18n.banner_inapp_title | default: 'banner.inapp.title' | t %}
-{% assign inapp_description = block.settings.inapp_description | default: frak_i18n.banner_inapp_description | default: 'banner.inapp.description' | t %}
-{% assign inapp_cta = block.settings.inapp_cta | default: frak_i18n.banner_inapp_cta | default: 'banner.inapp.cta' | t %}
+{% assign referral_title_fallback = 'banner.referral.title' | t %}
+{% assign referral_description_fallback = 'banner.referral.description' | t %}
+{% assign referral_cta_fallback = 'banner.referral.cta' | t %}
+{% assign inapp_title_fallback = 'banner.inapp.title' | t %}
+{% assign inapp_description_fallback = 'banner.inapp.description' | t %}
+{% assign inapp_cta_fallback = 'banner.inapp.cta' | t %}
+{% assign referral_title = block.settings.referral_title | default: frak_i18n.banner_referral_title | default: referral_title_fallback %}
+{% assign referral_description = block.settings.referral_description | default: frak_i18n.banner_referral_description | default: referral_description_fallback %}
+{% assign referral_cta = block.settings.referral_cta | default: frak_i18n.banner_referral_cta | default: referral_cta_fallback %}
+{% assign inapp_title = block.settings.inapp_title | default: frak_i18n.banner_inapp_title | default: inapp_title_fallback %}
+{% assign inapp_description = block.settings.inapp_description | default: frak_i18n.banner_inapp_description | default: inapp_description_fallback %}
+{% assign inapp_cta = block.settings.inapp_cta | default: frak_i18n.banner_inapp_cta | default: inapp_cta_fallback %}
 
 <frak-banner
   classname="{{ custom_class }}"
@@ -69,19 +77,19 @@
       "type": "text",
       "id": "referral_title",
       "label": "Title",
-      "info": "Override the referral banner title (e.g. \"You've been referred!\")"
+      "info": "Leave blank for the localized default (e.g. \"You've been referred!\")."
     },
     {
       "type": "textarea",
       "id": "referral_description",
       "label": "Description",
-      "info": "Override the referral banner description"
+      "info": "Leave blank for the localized default."
     },
     {
       "type": "text",
       "id": "referral_cta",
       "label": "Button text",
-      "info": "Override the referral banner button text (default: \"Got it\")"
+      "info": "Leave blank for the localized default (e.g. \"Got it\")."
     },
     {
       "type": "header",
@@ -91,19 +99,19 @@
       "type": "text",
       "id": "inapp_title",
       "label": "Title",
-      "info": "Override the in-app browser banner title (e.g. \"Open in your browser\")"
+      "info": "Leave blank for the localized default (e.g. \"Open in your browser\")."
     },
     {
       "type": "textarea",
       "id": "inapp_description",
       "label": "Description",
-      "info": "Override the in-app browser banner description"
+      "info": "Leave blank for the localized default."
     },
     {
       "type": "text",
       "id": "inapp_cta",
       "label": "Button text",
-      "info": "Override the in-app browser banner button text (default: \"Open browser\")"
+      "info": "Leave blank for the localized default (e.g. \"Open browser\")."
     },
     {
       "type": "header",

--- a/apps/shopify/extensions/theme-components/blocks/banner.liquid
+++ b/apps/shopify/extensions/theme-components/blocks/banner.liquid
@@ -3,15 +3,27 @@
   {% assign custom_class = 'frak-banner-custom' %}
 {% endif %}
 
+{% comment %}
+  Resolution chain per text: per-block setting → translatable shop metafield
+  (managed via Translate & Adapt) → storefront-locale fallback (`| t`).
+  Skipping the attribute entirely lets the SDK fall back to its built-ins.
+{% endcomment %}
+{% assign referral_title = block.settings.referral_title | default: shop.metafields.frak.banner_referral_title | default: 'banner.referral.title' | t %}
+{% assign referral_description = block.settings.referral_description | default: shop.metafields.frak.banner_referral_description | default: 'banner.referral.description' | t %}
+{% assign referral_cta = block.settings.referral_cta | default: shop.metafields.frak.banner_referral_cta | default: 'banner.referral.cta' | t %}
+{% assign inapp_title = block.settings.inapp_title | default: shop.metafields.frak.banner_inapp_title | default: 'banner.inapp.title' | t %}
+{% assign inapp_description = block.settings.inapp_description | default: shop.metafields.frak.banner_inapp_description | default: 'banner.inapp.description' | t %}
+{% assign inapp_cta = block.settings.inapp_cta | default: shop.metafields.frak.banner_inapp_cta | default: 'banner.inapp.cta' | t %}
+
 <frak-banner
   classname="{{ custom_class }}"
   {% if block.settings.interaction != 'default' and block.settings.interaction != blank %}interaction="{{ block.settings.interaction }}"{% endif %}
-  {% if block.settings.referral_title != blank %}referral-title="{{ block.settings.referral_title }}"{% endif %}
-  {% if block.settings.referral_description != blank %}referral-description="{{ block.settings.referral_description }}"{% endif %}
-  {% if block.settings.referral_cta != blank %}referral-cta="{{ block.settings.referral_cta }}"{% endif %}
-  {% if block.settings.inapp_title != blank %}inapp-title="{{ block.settings.inapp_title }}"{% endif %}
-  {% if block.settings.inapp_description != blank %}inapp-description="{{ block.settings.inapp_description }}"{% endif %}
-  {% if block.settings.inapp_cta != blank %}inapp-cta="{{ block.settings.inapp_cta }}"{% endif %}
+  {% if referral_title != blank %}referral-title="{{ referral_title }}"{% endif %}
+  {% if referral_description != blank %}referral-description="{{ referral_description }}"{% endif %}
+  {% if referral_cta != blank %}referral-cta="{{ referral_cta }}"{% endif %}
+  {% if inapp_title != blank %}inapp-title="{{ inapp_title }}"{% endif %}
+  {% if inapp_description != blank %}inapp-description="{{ inapp_description }}"{% endif %}
+  {% if inapp_cta != blank %}inapp-cta="{{ inapp_cta }}"{% endif %}
   {% if block.settings.image_url != blank %}image-url="{{ block.settings.image_url | image_url: width: 200 }}"{% endif %}
   {% if block.settings.allow_inapp_redirect %}allow-inapp-redirect="true"{% endif %}
   {% if request.design_mode and block.settings.enable_preview %}preview="true" preview-mode="{{ block.settings.preview_mode }}"{% endif %}

--- a/apps/shopify/extensions/theme-components/blocks/banner.liquid
+++ b/apps/shopify/extensions/theme-components/blocks/banner.liquid
@@ -4,16 +4,18 @@
 {% endif %}
 
 {% comment %}
-  Resolution chain per text: per-block setting → translatable shop metafield
-  (managed via Translate & Adapt) → storefront-locale fallback (`| t`).
-  Skipping the attribute entirely lets the SDK fall back to its built-ins.
+  Resolution chain per text: per-block setting → translatable metaobject
+  field (`frak_i18n` entry with handle `default`, managed via Translate &
+  Adapt) → storefront-locale fallback (`| t`). Skipping the attribute
+  entirely lets the SDK fall back to its built-ins.
 {% endcomment %}
-{% assign referral_title = block.settings.referral_title | default: shop.metafields.frak.banner_referral_title | default: 'banner.referral.title' | t %}
-{% assign referral_description = block.settings.referral_description | default: shop.metafields.frak.banner_referral_description | default: 'banner.referral.description' | t %}
-{% assign referral_cta = block.settings.referral_cta | default: shop.metafields.frak.banner_referral_cta | default: 'banner.referral.cta' | t %}
-{% assign inapp_title = block.settings.inapp_title | default: shop.metafields.frak.banner_inapp_title | default: 'banner.inapp.title' | t %}
-{% assign inapp_description = block.settings.inapp_description | default: shop.metafields.frak.banner_inapp_description | default: 'banner.inapp.description' | t %}
-{% assign inapp_cta = block.settings.inapp_cta | default: shop.metafields.frak.banner_inapp_cta | default: 'banner.inapp.cta' | t %}
+{% assign frak_i18n = shop.metaobjects.frak_i18n.default %}
+{% assign referral_title = block.settings.referral_title | default: frak_i18n.banner_referral_title | default: 'banner.referral.title' | t %}
+{% assign referral_description = block.settings.referral_description | default: frak_i18n.banner_referral_description | default: 'banner.referral.description' | t %}
+{% assign referral_cta = block.settings.referral_cta | default: frak_i18n.banner_referral_cta | default: 'banner.referral.cta' | t %}
+{% assign inapp_title = block.settings.inapp_title | default: frak_i18n.banner_inapp_title | default: 'banner.inapp.title' | t %}
+{% assign inapp_description = block.settings.inapp_description | default: frak_i18n.banner_inapp_description | default: 'banner.inapp.description' | t %}
+{% assign inapp_cta = block.settings.inapp_cta | default: frak_i18n.banner_inapp_cta | default: 'banner.inapp.cta' | t %}
 
 <frak-banner
   classname="{{ custom_class }}"

--- a/apps/shopify/extensions/theme-components/blocks/referral_button.liquid
+++ b/apps/shopify/extensions/theme-components/blocks/referral_button.liquid
@@ -10,18 +10,18 @@
   {% assign custom_class = 'frak-share-button-custom' %}
 {% endif %}
 
-{% assign button_text = '' %}
-{% if block.settings.text == '' %}
-  {% assign button_text = 'share_btn.label' | t %}
-{% else %}
-  {% assign button_text = block.settings.text %}
-{% endif %}
+{% comment %}
+  Resolution chain per text: per-block setting → translatable shop metafield
+  (managed via Translate & Adapt) → storefront-locale fallback (`| t`).
+{% endcomment %}
+{% assign button_text = block.settings.text | default: shop.metafields.frak.button_share_text | default: 'share_btn.label' | t %}
+{% assign no_reward_text = block.settings.no_reward_text | default: shop.metafields.frak.button_share_no_reward_text | default: 'share_btn.no_reward' | t %}
 
 <frak-button-share
   text="{{ button_text }}"
   classname="button {{ button_class }} {{ full_width_class }} {{ custom_class }}"
   {% if block.settings.use_reward %}use-reward{% endif %}
-  {% if block.settings.no_reward_text != blank %}no-reward-text="{{ block.settings.no_reward_text }}"{% endif %}
+  {% if no_reward_text != blank %}no-reward-text="{{ no_reward_text }}"{% endif %}
   {% if block.settings.target_interaction != blank %}target-interaction="{{ block.settings.target_interaction }}"{% endif %}
   {% if request.design_mode and block.settings.enable_preview %}preview="true"{% endif %}
 ></frak-button-share>

--- a/apps/shopify/extensions/theme-components/blocks/referral_button.liquid
+++ b/apps/shopify/extensions/theme-components/blocks/referral_button.liquid
@@ -11,11 +11,13 @@
 {% endif %}
 
 {% comment %}
-  Resolution chain per text: per-block setting → translatable shop metafield
-  (managed via Translate & Adapt) → storefront-locale fallback (`| t`).
+  Resolution chain per text: per-block setting → translatable metaobject
+  field (`frak_i18n` entry with handle `default`, managed via Translate &
+  Adapt) → storefront-locale fallback (`| t`).
 {% endcomment %}
-{% assign button_text = block.settings.text | default: shop.metafields.frak.button_share_text | default: 'share_btn.label' | t %}
-{% assign no_reward_text = block.settings.no_reward_text | default: shop.metafields.frak.button_share_no_reward_text | default: 'share_btn.no_reward' | t %}
+{% assign frak_i18n = shop.metaobjects.frak_i18n.default %}
+{% assign button_text = block.settings.text | default: frak_i18n.button_share_text | default: 'share_btn.label' | t %}
+{% assign no_reward_text = block.settings.no_reward_text | default: frak_i18n.button_share_no_reward_text | default: 'share_btn.no_reward' | t %}
 
 <frak-button-share
   text="{{ button_text }}"

--- a/apps/shopify/extensions/theme-components/blocks/referral_button.liquid
+++ b/apps/shopify/extensions/theme-components/blocks/referral_button.liquid
@@ -13,11 +13,16 @@
 {% comment %}
   Resolution chain per text: per-block setting → translatable metaobject
   field (`frak_i18n` entry with handle `default`, managed via Translate &
-  Adapt) → storefront-locale fallback (`| t`).
+  Adapt) → storefront-locale fallback. The `| t` filter is applied to the
+  locale-key fallback BEFORE the `default` cascade — otherwise Liquid
+  pipes the resolved value (merchant text or metaobject field) through
+  `| t` and emits "Translation missing: {locale}. <text>".
 {% endcomment %}
 {% assign frak_i18n = shop.metaobjects.frak_i18n.default %}
-{% assign button_text = block.settings.text | default: frak_i18n.button_share_text | default: 'share_btn.label' | t %}
-{% assign no_reward_text = block.settings.no_reward_text | default: frak_i18n.button_share_no_reward_text | default: 'share_btn.no_reward' | t %}
+{% assign button_text_fallback = 'share_btn.label' | t %}
+{% assign no_reward_text_fallback = 'share_btn.no_reward' | t %}
+{% assign button_text = block.settings.text | default: frak_i18n.button_share_text | default: button_text_fallback %}
+{% assign no_reward_text = block.settings.no_reward_text | default: frak_i18n.button_share_no_reward_text | default: no_reward_text_fallback %}
 
 <frak-button-share
   text="{{ button_text }}"
@@ -43,7 +48,8 @@
     {
       "type": "text",
       "id": "text",
-      "label": "Button text"
+      "label": "Button text",
+      "info": "Leave blank for the localized default (e.g. \"Share and earn!\")."
     },
     {
       "type": "checkbox",
@@ -56,7 +62,7 @@
       "type": "text",
       "id": "no_reward_text",
       "label": "Fallback text (no reward)",
-      "info": "Text to show when reward is enabled but no reward is available"
+      "info": "Shown when rewards are enabled but no reward is available. Leave blank for the localized default."
     },
     {
       "type": "select",

--- a/apps/shopify/extensions/theme-components/locales/en.default.json
+++ b/apps/shopify/extensions/theme-components/locales/en.default.json
@@ -1,5 +1,18 @@
 {
     "share_btn": {
-        "label": "Share and earn!"
+        "label": "Share and earn!",
+        "no_reward": "Share and earn!"
+    },
+    "banner": {
+        "referral": {
+            "title": "You've been referred!",
+            "description": "Make your first purchase to unlock your reward.",
+            "cta": "Got it"
+        },
+        "inapp": {
+            "title": "Open in your browser",
+            "description": "For the best experience, open this page in your system browser.",
+            "cta": "Open browser"
+        }
     }
 }

--- a/apps/shopify/extensions/theme-components/locales/fr.json
+++ b/apps/shopify/extensions/theme-components/locales/fr.json
@@ -1,5 +1,18 @@
 {
     "share_btn": {
-        "label": "Partage et gagne !"
+        "label": "Partage et gagne !",
+        "no_reward": "Partage et gagne !"
+    },
+    "banner": {
+        "referral": {
+            "title": "Vous avez été parrainé !",
+            "description": "Effectuez votre premier achat pour débloquer votre récompense.",
+            "cta": "Compris"
+        },
+        "inapp": {
+            "title": "Ouvrir dans votre navigateur",
+            "description": "Pour une meilleure expérience, ouvrez cette page dans le navigateur de votre téléphone.",
+            "cta": "Ouvrir le navigateur"
+        }
     }
 }

--- a/apps/shopify/shopify.app.development.toml
+++ b/apps/shopify/shopify.app.development.toml
@@ -19,7 +19,7 @@ api_version = "2026-04"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_customer_events,read_orders,read_pixels,read_products,read_themes,write_pixels"
+scopes = "read_customer_events,read_metaobjects,read_orders,read_pixels,read_products,read_themes,unauthenticated_read_metaobjects,write_metaobject_definitions,write_metaobjects,write_pixels,write_translations"
 
 [auth]
 redirect_urls = [

--- a/apps/shopify/shopify.app.production.toml
+++ b/apps/shopify/shopify.app.production.toml
@@ -19,7 +19,7 @@ api_version = "2026-04"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_customer_events,read_orders,read_pixels,read_products,read_themes,write_pixels"
+scopes = "read_customer_events,read_metaobjects,read_orders,read_pixels,read_products,read_themes,unauthenticated_read_metaobjects,write_metaobject_definitions,write_metaobjects,write_pixels,write_translations"
 
 [auth]
 redirect_urls = [


### PR DESCRIPTION
## Summary

Brings i18n to the Shopify app surfaces and migrates translation storage from metafields to a `frak_i18n` metaobject so merchant edits survive app upgrades. Also fixes a couple of bugs uncovered along the way.

## Changes

### i18n + components
- Wire `react-i18next` into Shopify components (`3e5785c4c`)
- Add default post-purchase translations (en/fr) and the new app permissions needed for metaobject access (`1a80f68e0`)
- Localise `theme-components` `banner.liquid` and `referral_button.liquid`

### Metaobject migration
- Switch from metafields to a `frak_i18n` metaobject for translation storage (`c3b1712cc`)
- Tighten metaobject sync (`e2045a53b`):
  - Fix regional locale codes (`fr-CA` → `FR_CA`) in the Storefront query
  - Only seed EN values on first-time entry creation, preserving merchant edits
  - Combine def + entry presence into a single read query
  - Extract `runGraphQL` helper, drop GraphQL boilerplate from 5 call-sites
  - Share a `usePostPurchaseTextOverrides` hook between Thank You + Order Status
  - Drop legacy metafield cleanup (never deployed) and unused `displayNameKey` / `shopify.d.ts` declarations

### Bug fixes
- Fix liquid operator chaining in theme components (`8dc4549a8`)
- Use `metaobjectByHandle(handle:)` for Admin API 2026-04 (`b8c9af28c`) — `metaobject(handle:)` was removed, causing `ensureFrakI18nMetaobject` to bail before creating the definition / singleton entry on fresh stores

## Commits

- `3e5785c4c` 🌐 Add i18n to shopify components
- `1a80f68e0` 🌐 Add default post purchase translation + new permissions on the app
- `c3b1712cc` ♻️ Switch from metafields to metaobject for translation
- `e2045a53b` ♻️ Tighten frak_i18n metaobject sync + extract shared hook
- `8dc4549a8` 🐛 Correct liquid operator chaining
- `b8c9af28c` 🐛 Use metaobjectByHandle on Admin API 2026-04
