### PR TITLE
🔥 Remove default UTM flags from frakContext attribution

### DIFF
--- a/.changeset/remove-default-utm-flags.md
+++ b/.changeset/remove-default-utm-flags.md
@@ -1,0 +1,7 @@
+---
+"@frak-labs/core-sdk": patch
+---
+
+Stop injecting default UTM flags when building attribution URLs. Previously `FrakContextManager.update` (and anything routing through `applyAttributionParams`) auto-filled `utm_medium=referral`, `via=frak`, and on V2 contexts also `utm_campaign` / `ref` from the context payload. This polluted merchant analytics and overrode codes integrators wanted to own.
+
+Only `utm_source` keeps its `frak` default; `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `via`, and `ref` are now opt-in via `AttributionParams`.

--- a/sdk/core/src/context/frakContext.test.ts
+++ b/sdk/core/src/context/frakContext.test.ts
@@ -218,14 +218,6 @@ describe("FrakContextManager", () => {
                     expect(parsedUrl.searchParams.get("utm_source")).toBe(
                         "frak"
                     );
-                    expect(parsedUrl.searchParams.get("utm_medium")).toBe(
-                        "referral"
-                    );
-                    expect(parsedUrl.searchParams.get("utm_campaign")).toBe(
-                        v2Context.m
-                    );
-                    expect(parsedUrl.searchParams.get("via")).toBe("frak");
-                    expect(parsedUrl.searchParams.get("ref")).toBe(v2Context.c);
                 });
 
                 it("should apply default attribution params when attribution is an empty object", () => {
@@ -240,18 +232,6 @@ describe("FrakContextManager", () => {
                     expect(parsedUrl.searchParams.get("utm_source")).toBe(
                         "frak"
                     );
-                    expect(parsedUrl.searchParams.get("utm_medium")).toBe(
-                        "referral"
-                    );
-                    expect(parsedUrl.searchParams.get("utm_campaign")).toBe(
-                        v2Context.m
-                    );
-                    expect(parsedUrl.searchParams.get("via")).toBe("frak");
-                    expect(parsedUrl.searchParams.get("ref")).toBe(v2Context.c);
-                    expect(
-                        parsedUrl.searchParams.get("utm_content")
-                    ).toBeNull();
-                    expect(parsedUrl.searchParams.get("utm_term")).toBeNull();
                 });
 
                 it("should honor overrides over defaults", () => {
@@ -306,11 +286,6 @@ describe("FrakContextManager", () => {
                     expect(parsedUrl.searchParams.get("utm_campaign")).toBe(
                         "merchant-spring"
                     );
-                    // Missing ones filled by Frak defaults
-                    expect(parsedUrl.searchParams.get("utm_medium")).toBe(
-                        "referral"
-                    );
-                    expect(parsedUrl.searchParams.get("ref")).toBe(v2Context.c);
                 });
 
                 it("should skip fields with empty-string overrides", () => {
@@ -325,6 +300,14 @@ describe("FrakContextManager", () => {
                         false
                     );
                     expect(parsedUrl.searchParams.has("utm_term")).toBe(false);
+                    expect(parsedUrl.searchParams.has("utm_medium")).toBe(
+                        false
+                    );
+                    expect(parsedUrl.searchParams.has("utm_campaign")).toBe(
+                        false
+                    );
+                    expect(parsedUrl.searchParams.has("via")).toBe(false);
+                    expect(parsedUrl.searchParams.has("ref")).toBe(false);
                 });
 
                 it("should skip context-derived defaults for V1 (no merchantId/clientId)", () => {
@@ -342,15 +325,6 @@ describe("FrakContextManager", () => {
                     expect(parsedUrl.searchParams.get("utm_source")).toBe(
                         "frak"
                     );
-                    expect(parsedUrl.searchParams.get("utm_medium")).toBe(
-                        "referral"
-                    );
-                    expect(parsedUrl.searchParams.get("via")).toBe("frak");
-                    // No derivable values from V1
-                    expect(parsedUrl.searchParams.has("utm_campaign")).toBe(
-                        false
-                    );
-                    expect(parsedUrl.searchParams.has("ref")).toBe(false);
                 });
             });
         });

--- a/sdk/core/src/context/frakContext.ts
+++ b/sdk/core/src/context/frakContext.ts
@@ -92,11 +92,6 @@ function parse({ url }: { url: string }): FrakContext | null | undefined {
 }
 
 /**
- * Default UTM medium value when attribution is requested.
- */
-const DEFAULT_UTM_MEDIUM = "referral";
-
-/**
  * Default utm_source / via value when attribution is requested.
  */
 const DEFAULT_ATTRIBUTION_SOURCE = "frak";
@@ -110,18 +105,16 @@ const DEFAULT_ATTRIBUTION_SOURCE = "frak";
  * addresses leaking into UTM params. V1 contexts have no equivalent.
  */
 function resolveAttributionValues(
-    context: FrakContextV1 | FrakContextV2,
     overrides: AttributionParams
 ): Record<string, string | undefined> {
-    const isV2 = isV2Context(context);
     return {
         utm_source: overrides.utmSource ?? DEFAULT_ATTRIBUTION_SOURCE,
-        utm_medium: overrides.utmMedium ?? DEFAULT_UTM_MEDIUM,
-        utm_campaign: overrides.utmCampaign ?? (isV2 ? context.m : undefined),
+        utm_medium: overrides.utmMedium ?? undefined,
+        utm_campaign: overrides.utmCampaign ?? undefined,
         utm_content: overrides.utmContent,
         utm_term: overrides.utmTerm,
-        via: overrides.via ?? DEFAULT_ATTRIBUTION_SOURCE,
-        ref: overrides.ref ?? (isV2 ? context.c : undefined),
+        via: overrides.via ?? undefined,
+        ref: overrides.ref ?? undefined,
     };
 }
 
@@ -133,10 +126,9 @@ function resolveAttributionValues(
  */
 function applyAttributionParams(
     urlObj: URL,
-    context: FrakContextV1 | FrakContextV2,
     attribution?: AttributionParams
 ): void {
-    const values = resolveAttributionValues(context, attribution ?? {});
+    const values = resolveAttributionValues(attribution ?? {});
     for (const [key, value] of Object.entries(values)) {
         if (value === undefined || value === "") continue;
         if (urlObj.searchParams.has(key)) continue;
@@ -174,7 +166,7 @@ function update({
 
     const urlObj = new URL(url);
     urlObj.searchParams.set(contextKey, compressedContext);
-    applyAttributionParams(urlObj, context, attribution);
+    applyAttributionParams(urlObj, attribution);
     return urlObj.toString();
 }
 


### PR DESCRIPTION
## Summary

Drops the default UTM flags injected by `frakContext` when building attribution URLs. Defaults (`utm_medium=referral`, `utm_source=frak`, `via=frak`, plus auto-filled `utm_campaign` / `ref` from the V2 context) now stay empty unless the caller explicitly opts in via `AttributionParams`.

## Why

The defaults polluted merchant analytics with Frak-branded UTM values and overrode the campaign / referrer codes that integrators wanted to manage themselves. Only `utm_source` keeps its `frak` default; everything else is opt-in.

## Changes

- `sdk/core/src/context/frakContext.ts` — remove `DEFAULT_UTM_MEDIUM`, drop V2-context auto-fill for `utm_campaign` / `ref` / `via`, simplify `resolveAttributionValues` / `applyAttributionParams` signatures
- `sdk/core/src/context/frakContext.test.ts` — updated expectations (no default `utm_medium`, no auto `utm_campaign` / `ref`)

## Commits

- `85866f461` 🔥 Remove default utm flags
