### PR TITLE
feat(shopify): move manual button/banner install into Appearance tab

### DIFF
--- a/apps/shopify/app/components/Appearance/ManualBannerInstall.tsx
+++ b/apps/shopify/app/components/Appearance/ManualBannerInstall.tsx
@@ -1,0 +1,40 @@
+import { CopyableSnippet } from "app/components/ui/CopyableSnippet";
+import { ExternalLink } from "app/components/ui/ExternalLink";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Manual banner install for themes without in-page app blocks (intermediate +
+ * legacy). The `<frak-banner>` web component is pasted into the theme layout;
+ * wording/colors/rewards are managed in the Frak business editor.
+ */
+const BANNER_TAG = "<frak-banner></frak-banner>";
+
+export function ManualBannerInstall({
+    themeLiquidUrl,
+    customizeUrl,
+}: {
+    themeLiquidUrl: string;
+    customizeUrl: string;
+}) {
+    const { t } = useTranslation();
+    return (
+        <s-section>
+            <s-stack gap="base">
+                <s-text>{t("appearance.manual.bannerDescription")}</s-text>
+
+                <CopyableSnippet snippet={BANNER_TAG} />
+
+                <ExternalLink href={themeLiquidUrl}>
+                    {t("appearance.manual.editTheme")}
+                </ExternalLink>
+
+                <s-stack gap="small-100" alignItems="start">
+                    <s-text>{t("appearance.manual.customizeNote")}</s-text>
+                    <ExternalLink href={customizeUrl}>
+                        {t("appearance.manual.openEditor")}
+                    </ExternalLink>
+                </s-stack>
+            </s-stack>
+        </s-section>
+    );
+}

--- a/apps/shopify/app/components/Appearance/ManualButtonInstall.tsx
+++ b/apps/shopify/app/components/Appearance/ManualButtonInstall.tsx
@@ -1,0 +1,61 @@
+import {
+    CopyableSnippet,
+    inlineCodeClass,
+} from "app/components/ui/CopyableSnippet";
+import { ExternalLink } from "app/components/ui/ExternalLink";
+import { Trans, useTranslation } from "react-i18next";
+
+/**
+ * Manual share-button install for themes without in-page app blocks
+ * (intermediate + legacy). Mirrors the OS-2.0 ButtonTab intent but via a
+ * copy-paste web-component tag plus deep-links to the theme editor and the
+ * Frak business editor — the same shape the Settings → Theme page used to show.
+ */
+const BUTTON_TAG = '<frak-button-share classname="btn"></frak-button-share>';
+
+export function ManualButtonInstall({
+    productTemplateUrl,
+    customizeUrl,
+}: {
+    productTemplateUrl: string;
+    customizeUrl: string;
+}) {
+    const { t } = useTranslation();
+    return (
+        <s-section>
+            <s-stack gap="base">
+                <s-text>{t("appearance.manual.buttonDescription")}</s-text>
+
+                <CopyableSnippet snippet={BUTTON_TAG} />
+
+                <s-text color="subdued">
+                    <Trans
+                        i18nKey="appearance.manual.classHint"
+                        components={{
+                            code: <code className={inlineCodeClass} />,
+                        }}
+                    />
+                </s-text>
+                <s-text color="subdued">
+                    <Trans
+                        i18nKey="appearance.manual.sectionHint"
+                        components={{
+                            code: <code className={inlineCodeClass} />,
+                        }}
+                    />
+                </s-text>
+
+                <ExternalLink href={productTemplateUrl}>
+                    {t("appearance.manual.editProductTemplate")}
+                </ExternalLink>
+
+                <s-stack gap="small-100" alignItems="start">
+                    <s-text>{t("appearance.manual.customizeNote")}</s-text>
+                    <ExternalLink href={customizeUrl}>
+                        {t("appearance.manual.openEditor")}
+                    </ExternalLink>
+                </s-stack>
+            </s-stack>
+        </s-section>
+    );
+}

--- a/apps/shopify/app/components/IntermediateInstall/index.tsx
+++ b/apps/shopify/app/components/IntermediateInstall/index.tsx
@@ -1,54 +1,24 @@
 import { Activated } from "app/components/Activated";
-import styles from "app/components/LegacyInstall/LegacyInstall.module.css";
 import { ExternalLink } from "app/components/ui/ExternalLink";
-import { useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
-
-/**
- * The share-button web component merchants paste into their product template.
- * `classname` reuses the theme's own button class so the (light-DOM) button
- * inherits the store's native styling.
- */
-const BUTTON_TAG = '<frak-button-share classname="btn"></frak-button-share>';
+import { useTranslation } from "react-i18next";
 
 /**
  * Install flow for the "intermediate" theme case: the theme supports app embeds
  * (so the global Frak Listener works, e.g. on vintage themes like Debut) but
  * NOT in-page app blocks. The Listener is enabled exactly like on a full OS 2.0
- * theme — no manual SDK snippet needed — while the share button falls back to a
- * pasted web component because it can't be dropped into the page builder.
+ * theme — no manual SDK snippet needed. The share button and banner live in the
+ * Appearance tab (manual copy-paste view), so they're not duplicated here.
  */
 export function IntermediateInstall({
     isThemeHasFrakActivated,
     editorUrl,
     listenerAppEmbedId,
-    productTemplateUrl,
-    customizeUrl,
 }: {
     isThemeHasFrakActivated: boolean;
     editorUrl: string;
     listenerAppEmbedId: string;
-    productTemplateUrl: string;
-    customizeUrl: string;
 }) {
     const { t } = useTranslation();
-    const [copied, setCopied] = useState(false);
-    const [copyError, setCopyError] = useState(false);
-
-    function copyButtonTag() {
-        if (!navigator.clipboard?.writeText) {
-            setCopyError(true);
-            return;
-        }
-        navigator.clipboard.writeText(BUTTON_TAG).then(
-            () => {
-                setCopyError(false);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-            },
-            () => setCopyError(true)
-        );
-    }
 
     return (
         <s-stack gap="large">
@@ -63,7 +33,7 @@ export function IntermediateInstall({
                 </s-stack>
             </s-banner>
 
-            {/* Step 1 — enable the Listener app embed (works on this theme). */}
+            {/* Enable the Listener app embed (works on this theme). */}
             <s-section>
                 <s-stack gap="base">
                     <s-heading>{t("theme.intermediate.embedTitle")}</s-heading>
@@ -84,57 +54,6 @@ export function IntermediateInstall({
                             </ExternalLink>
                         </>
                     )}
-                </s-stack>
-            </s-section>
-
-            {/* Step 2 — manual share button (optional). */}
-            <s-section>
-                <s-stack gap="base">
-                    <s-heading>{t("theme.intermediate.buttonTitle")}</s-heading>
-                    <s-text>{t("theme.legacy.step2")}</s-text>
-
-                    <div className={styles.snippetWrapper}>
-                        <pre className={styles.snippet}>{BUTTON_TAG}</pre>
-                        <div className={styles.copyButton}>
-                            <s-button variant="primary" onClick={copyButtonTag}>
-                                {copied
-                                    ? t("theme.legacy.copied")
-                                    : t("theme.legacy.copyButton")}
-                            </s-button>
-                        </div>
-                    </div>
-                    {copyError && (
-                        <s-text color="subdued">
-                            {t("theme.legacy.copyError")}
-                        </s-text>
-                    )}
-
-                    <s-text color="subdued">
-                        <Trans
-                            i18nKey="theme.legacy.step2ClassHint"
-                            components={{
-                                code: <code className={styles.inlineCode} />,
-                            }}
-                        />
-                    </s-text>
-                    <s-text color="subdued">
-                        <Trans
-                            i18nKey="theme.legacy.step2SectionHint"
-                            components={{
-                                code: <code className={styles.inlineCode} />,
-                            }}
-                        />
-                    </s-text>
-                    <ExternalLink href={productTemplateUrl}>
-                        {t("theme.legacy.step2Link")}
-                    </ExternalLink>
-
-                    <s-stack gap="small-100" alignItems="start">
-                        <s-text>{t("theme.legacy.step3")}</s-text>
-                        <ExternalLink href={customizeUrl}>
-                            {t("theme.legacy.step3Link")}
-                        </ExternalLink>
-                    </s-stack>
                 </s-stack>
             </s-section>
         </s-stack>

--- a/apps/shopify/app/components/ui/CopyableSnippet/CopyableSnippet.module.css
+++ b/apps/shopify/app/components/ui/CopyableSnippet/CopyableSnippet.module.css
@@ -1,0 +1,33 @@
+.wrapper {
+    position: relative;
+}
+
+.snippet {
+    background: #f6f6f7;
+    border: 1px solid #e1e3e5;
+    border-radius: 8px;
+    padding: 12px;
+    font-size: 12px;
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    white-space: pre;
+    overflow-x: auto;
+    color: #202223;
+    margin: 0;
+}
+
+.copyButton {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+}
+
+.inlineCode {
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.9em;
+    background: #f1f2f3;
+    border-radius: 4px;
+    padding: 1px 5px;
+    color: #202223;
+}

--- a/apps/shopify/app/components/ui/CopyableSnippet/index.tsx
+++ b/apps/shopify/app/components/ui/CopyableSnippet/index.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import styles from "./CopyableSnippet.module.css";
+
+/**
+ * A read-only code block with a copy-to-clipboard button. The embedded admin
+ * iframe often blocks clipboard-write, so on failure we surface a "select it
+ * manually" hint instead of failing silently — the <pre> stays selectable.
+ *
+ * i18n labels default to the shared `appearance.manual.*` keys but can be
+ * overridden per usage.
+ */
+export function CopyableSnippet({
+    snippet,
+    copyLabelKey = "appearance.manual.copyTag",
+    copiedLabelKey = "appearance.manual.copied",
+    errorLabelKey = "appearance.manual.copyError",
+}: {
+    snippet: string;
+    copyLabelKey?: string;
+    copiedLabelKey?: string;
+    errorLabelKey?: string;
+}) {
+    const { t } = useTranslation();
+    const [copied, setCopied] = useState(false);
+    const [error, setError] = useState(false);
+
+    function copy() {
+        if (!navigator.clipboard?.writeText) {
+            setError(true);
+            return;
+        }
+        navigator.clipboard.writeText(snippet).then(
+            () => {
+                setError(false);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+            },
+            () => setError(true)
+        );
+    }
+
+    return (
+        <div className={styles.wrapper}>
+            <pre className={styles.snippet}>{snippet}</pre>
+            <div className={styles.copyButton}>
+                <s-button variant="primary" onClick={copy}>
+                    {copied ? t(copiedLabelKey) : t(copyLabelKey)}
+                </s-button>
+            </div>
+            {error && <s-text color="subdued">{t(errorLabelKey)}</s-text>}
+        </div>
+    );
+}
+
+/** Shared inline-code class for `<code>` inside Trans hints. */
+export const inlineCodeClass = styles.inlineCode;

--- a/apps/shopify/app/i18n/locales/en/translation.json
+++ b/apps/shopify/app/i18n/locales/en/translation.json
@@ -129,9 +129,8 @@
         "todo": "Please activate the Frak application in your theme by following the instructions below",
         "intermediate": {
             "banner": "Your theme supports app embeds but not in-page app blocks",
-            "bannerDescription": "The Frak Listener runs globally through an app embed — no manual code needed. Only the share button can't be dropped into your product page automatically, so add it manually below.",
-            "embedTitle": "1. Enable the Frak Listener",
-            "buttonTitle": "2. Add the share button (optional)"
+            "bannerDescription": "The Frak Listener runs globally through an app embed — no manual code needed. The share button and banner can't be dropped into your pages automatically; add them from the Appearance tab.",
+            "embedTitle": "Enable the Frak Listener"
         },
         "legacy": {
             "upgradeWarning": "Your theme does not support Online Store 2.0",
@@ -445,6 +444,19 @@
         "legacy": {
             "customizationsNote": "Your theme does not support Shopify app blocks. Logo, wording and reward settings are managed in the Frak editor on the business dashboard.",
             "openEditor": "Open Frak editor"
+        },
+        "manual": {
+            "buttonDescription": "Your theme doesn't support in-page app blocks. Paste this tag where you want the share button (usually near the Add to cart button).",
+            "bannerDescription": "Your theme doesn't support in-page app blocks. Paste this tag where you want the referral banner to appear (e.g. near the top of your theme.liquid).",
+            "classHint": "Replace <code>btn</code> with your theme's button class so it matches your store (e.g. <code>btn</code> on most vintage themes, <code>button</code> on Dawn).",
+            "sectionHint": "If your product template only contains a <code>{% section %}</code> tag, open that section file instead (e.g. <code>sections/product-template.liquid</code>).",
+            "editProductTemplate": "Edit product template",
+            "editTheme": "Edit theme.liquid",
+            "customizeNote": "Personalise wording, colors and rewards in the Frak editor:",
+            "openEditor": "Open Frak editor",
+            "copyTag": "Copy the tag",
+            "copied": "Copied!",
+            "copyError": "Couldn't copy automatically — select the tag above and copy it manually."
         }
     },
     "funding": {

--- a/apps/shopify/app/i18n/locales/fr/translation.json
+++ b/apps/shopify/app/i18n/locales/fr/translation.json
@@ -129,9 +129,8 @@
         "todo": "Veuillez activer l'application Frak dans votre thème en suivant les instructions ci-dessous",
         "intermediate": {
             "banner": "Votre thème prend en charge les app embeds mais pas les blocs d'application dans les pages",
-            "bannerDescription": "Le Frak Listener fonctionne globalement via un app embed — aucun code manuel nécessaire. Seul le bouton de partage ne peut pas être ajouté automatiquement dans votre page produit, ajoutez-le donc manuellement ci-dessous.",
-            "embedTitle": "1. Activer le Frak Listener",
-            "buttonTitle": "2. Ajouter le bouton de partage (optionnel)"
+            "bannerDescription": "Le Frak Listener fonctionne globalement via un app embed — aucun code manuel nécessaire. Le bouton de partage et la bannière ne peuvent pas être ajoutés automatiquement dans vos pages ; ajoutez-les depuis l'onglet Apparence.",
+            "embedTitle": "Activer le Frak Listener"
         },
         "legacy": {
             "upgradeWarning": "Votre thème ne prend pas en charge Online Store 2.0",
@@ -446,6 +445,19 @@
         "legacy": {
             "customizationsNote": "Votre thème ne prend pas en charge les blocs d'application Shopify. Le logo, les textes et les récompenses sont gérés depuis l'éditeur Frak sur le tableau de bord business.",
             "openEditor": "Ouvrir l'éditeur Frak"
+        },
+        "manual": {
+            "buttonDescription": "Votre thème ne prend pas en charge les blocs d'application dans les pages. Collez cette balise là où vous souhaitez le bouton de partage (généralement près du bouton Ajouter au panier).",
+            "bannerDescription": "Votre thème ne prend pas en charge les blocs d'application dans les pages. Collez cette balise là où vous souhaitez afficher la bannière de parrainage (ex. en haut de votre theme.liquid).",
+            "classHint": "Remplacez <code>btn</code> par la classe de bouton de votre thème pour qu'il s'harmonise (ex. <code>btn</code> sur la plupart des thèmes vintage, <code>button</code> sur Dawn).",
+            "sectionHint": "Si votre modèle de produit ne contient qu'une balise <code>{% section %}</code>, ouvrez plutôt ce fichier de section (ex. <code>sections/product-template.liquid</code>).",
+            "editProductTemplate": "Modifier le modèle produit",
+            "editTheme": "Modifier theme.liquid",
+            "customizeNote": "Personnalisez les textes, couleurs et récompenses dans l'éditeur Frak :",
+            "openEditor": "Ouvrir l'éditeur Frak",
+            "copyTag": "Copier la balise",
+            "copied": "Copié !",
+            "copyError": "Copie automatique impossible — sélectionnez la balise ci-dessus et copiez-la manuellement."
         }
     },
     "funding": {

--- a/apps/shopify/app/routes/app.appearance.tsx
+++ b/apps/shopify/app/routes/app.appearance.tsx
@@ -3,6 +3,8 @@ import { ButtonTab } from "app/components/Appearance/ButtonTab";
 import { CheckoutExtensionTab } from "app/components/Appearance/CheckoutExtensionTab";
 import { CustomizationsTab } from "app/components/Appearance/CustomizationsTab";
 import { ExplorerTab } from "app/components/Appearance/ExplorerTab";
+import { ManualBannerInstall } from "app/components/Appearance/ManualBannerInstall";
+import { ManualButtonInstall } from "app/components/Appearance/ManualButtonInstall";
 import { Skeleton } from "app/components/Skeleton";
 import { ExternalButton } from "app/components/ui/ExternalLink";
 import { PageHeading } from "app/components/ui/PageHeading";
@@ -287,11 +289,16 @@ export default function AppearancePage() {
     const shopName = rootData?.shop?.name ?? "My Store";
     const businessUrl = rootData?.businessUrl ?? "";
     const merchantId = rootData?.merchantId;
+    const shopDomain = rootData?.shop?.myshopifyDomain;
     // Deep-link the legacy "Open editor" straight to the branding editor, same
     // as the dashboard's manual-install step 3.
     const customizeUrl = merchantId
         ? `${businessUrl}/m/${merchantId}/merchant/customize`
         : businessUrl;
+    // Deep-links for the manual (non-app-block) button/banner install.
+    const themeBase = `https://${shopDomain}/admin/themes/current`;
+    const productTemplateUrl = `${themeBase}?key=templates/product.liquid`;
+    const themeLiquidUrl = `${themeBase}?key=layout/theme.liquid`;
     const isThemeSupportedPromise = rootData?.isThemeSupportedPromise;
     const { t } = useTranslation();
     const [selectedTab, setSelectedTab] = useState(0);
@@ -319,18 +326,11 @@ export default function AppearancePage() {
         },
     ];
 
-    // Legacy themes drop the Banner/Button tabs (they write Shopify metafields
-    // only the OS-2.0 block reads). Customizations stays but redirects to the
-    // Frak editor; Explorer + Checkout Extension are backend-driven.
-    const legacyTabs = fullTabs.filter(
-        (tab) => tab.id !== "share-button" && tab.id !== "banner"
-    );
-
-    // Single renderer keyed on the tab id (robust to the differing tab sets);
-    // only Customizations differs between modes.
+    // Single renderer keyed on the tab id. Every theme sees all tabs; the
+    // Customizations / Share Button / Banner tabs swap to a manual (copy-paste
+    // + redirect) view when the theme can't host in-page app blocks.
     const renderTabContent = (isThemeSupported: boolean) => {
-        const tabs = isThemeSupported ? fullTabs : legacyTabs;
-        switch (tabs[selectedTab]?.id) {
+        switch (fullTabs[selectedTab]?.id) {
             case "customizations":
                 return isThemeSupported ? (
                     <CustomizationsTab
@@ -366,15 +366,25 @@ export default function AppearancePage() {
                     />
                 );
             case "share-button":
-                return (
+                return isThemeSupported ? (
                     <ButtonTab
                         isThemeHasFrakButton={isThemeHasFrakButton}
                         firstProduct={firstProduct}
                     />
+                ) : (
+                    <ManualButtonInstall
+                        productTemplateUrl={productTemplateUrl}
+                        customizeUrl={customizeUrl}
+                    />
                 );
             case "banner":
-                return (
+                return isThemeSupported ? (
                     <BannerTab isThemeHasFrakBanner={isThemeHasFrakBanner} />
+                ) : (
+                    <ManualBannerInstall
+                        themeLiquidUrl={themeLiquidUrl}
+                        customizeUrl={customizeUrl}
+                    />
                 );
             case "checkout-extension":
                 return <CheckoutExtensionTab />;
@@ -392,7 +402,7 @@ export default function AppearancePage() {
                         const supported = isThemeSupported ?? true;
                         return (
                             <Tabs
-                                tabs={supported ? fullTabs : legacyTabs}
+                                tabs={fullTabs}
                                 selected={selectedTab}
                                 onSelect={setSelectedTab}
                             >

--- a/apps/shopify/app/routes/app.settings.theme.tsx
+++ b/apps/shopify/app/routes/app.settings.theme.tsx
@@ -52,16 +52,12 @@ export default function SettingsThemePage() {
     const { t } = useTranslation();
     const shopDomain = rootData?.shop.myshopifyDomain;
     const editorUrl = `https://${shopDomain}/admin/themes/current/editor`;
-    const productTemplateUrl = `https://${shopDomain}/admin/themes/current?key=templates/product.liquid`;
     const refresh = useRefreshData();
     const isThemeSupportedPromise = rootData?.isThemeSupportedPromise;
     const merchantId = rootData?.merchantId ?? null;
     const walletUrl = rootData?.walletUrl ?? "";
     const componentsUrl = rootData?.componentsUrl ?? "";
     const businessUrl = rootData?.businessUrl ?? "";
-    const customizeUrl = merchantId
-        ? `${businessUrl}/m/${merchantId}/merchant/customize`
-        : businessUrl;
 
     useVisibilityChange(
         useCallback(() => {
@@ -106,8 +102,6 @@ export default function SettingsThemePage() {
                                 }
                                 editorUrl={editorUrl}
                                 listenerAppEmbedId={id ?? ""}
-                                productTemplateUrl={productTemplateUrl}
-                                customizeUrl={customizeUrl}
                             />
                         ) : (
                             <LegacyInstall


### PR DESCRIPTION
For themes without in-page app blocks (intermediate + legacy), the Appearance tab now keeps the Share Button and Banner tabs instead of dropping them, showing a manual copy-paste + redirect view (theme editor + Frak business editor) — mirroring the Settings > Theme flow.

- add shared CopyableSnippet UI (copy-to-clipboard with manual-select fallback)
- add ManualButtonInstall / ManualBannerInstall for the non-app-block view
- appearance: render manual views when the theme lacks app blocks; drop the legacyTabs filtering so all tabs stay visible
- remove the duplicated share-button step from IntermediateInstall; point merchants to the Appearance tab instead
- i18n: add appearance.manual.* keys (en + fr)