### PR TITLE
feat(wallet): haptic buzz on incoming signature request

### DIFF
--- a/apps/wallet/app/module/pairing/component/TargetSignatureModal/index.tsx
+++ b/apps/wallet/app/module/pairing/component/TargetSignatureModal/index.tsx
@@ -20,7 +20,6 @@ import { Check, Shield, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useStore } from "zustand";
-import { notifyHaptic } from "@/utils/haptics";
 import * as styles from "./index.css";
 
 /**
@@ -59,9 +58,6 @@ function InnerTargetSignatureModal() {
 
     const [isDismissed, setIsDismissed] = useState(false);
     const knownIdsRef = useRef<Set<string>>(new Set());
-    // Distinguishes the first effect run (requests already pending at mount)
-    // from genuinely new arrivals — only the latter should buzz.
-    const hasMountedRef = useRef(false);
 
     // Re-open the modal when a NEW signature ID appears. Removals (sign/decline)
     // must NOT reset the dismissed state — otherwise the modal would jump back
@@ -76,14 +72,7 @@ function InnerTargetSignatureModal() {
             }
         }
         knownIdsRef.current = ids;
-        if (hasNew) {
-            setIsDismissed(false);
-            // Small haptic buzz to surface the incoming request (native on
-            // mobile, navigator.vibrate fallback on web). Skipped on mount so
-            // pre-existing pending requests don't buzz on every remount.
-            if (hasMountedRef.current) void notifyHaptic();
-        }
-        hasMountedRef.current = true;
+        if (hasNew) setIsDismissed(false);
     }, [requests]);
 
     if (total === 0 || !currentRequest) return null;

--- a/apps/wallet/app/module/pairing/component/TargetSignatureModal/index.tsx
+++ b/apps/wallet/app/module/pairing/component/TargetSignatureModal/index.tsx
@@ -20,6 +20,7 @@ import { Check, Shield, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import { notifyHaptic } from "@/utils/haptics";
 import * as styles from "./index.css";
 
 /**
@@ -58,6 +59,9 @@ function InnerTargetSignatureModal() {
 
     const [isDismissed, setIsDismissed] = useState(false);
     const knownIdsRef = useRef<Set<string>>(new Set());
+    // Distinguishes the first effect run (requests already pending at mount)
+    // from genuinely new arrivals — only the latter should buzz.
+    const hasMountedRef = useRef(false);
 
     // Re-open the modal when a NEW signature ID appears. Removals (sign/decline)
     // must NOT reset the dismissed state — otherwise the modal would jump back
@@ -72,7 +76,14 @@ function InnerTargetSignatureModal() {
             }
         }
         knownIdsRef.current = ids;
-        if (hasNew) setIsDismissed(false);
+        if (hasNew) {
+            setIsDismissed(false);
+            // Small haptic buzz to surface the incoming request (native on
+            // mobile, navigator.vibrate fallback on web). Skipped on mount so
+            // pre-existing pending requests don't buzz on every remount.
+            if (hasMountedRef.current) void notifyHaptic();
+        }
+        hasMountedRef.current = true;
     }, [requests]);
 
     if (total === 0 || !currentRequest) return null;

--- a/apps/wallet/app/module/pairing/hook/useSignatureRequestHaptics.ts
+++ b/apps/wallet/app/module/pairing/hook/useSignatureRequestHaptics.ts
@@ -1,0 +1,34 @@
+import { getTargetPairingClient } from "@frak-labs/wallet-shared";
+import { useEffect } from "react";
+import { notifyHaptic } from "@/utils/haptics";
+
+/**
+ * Fire a short haptic buzz whenever a genuinely new signature request lands
+ * in the target pairing client.
+ *
+ * Subscribes directly to the client's store (single source of truth) instead
+ * of reacting to component renders, so it fires exactly once per arrival
+ * regardless of what UI is mounted. Requests already pending when the
+ * subscription attaches are seeded as "known" and do not buzz.
+ *
+ * Mounted once at the app root.
+ */
+export function useSignatureRequestHaptics() {
+    useEffect(() => {
+        const { store } = getTargetPairingClient();
+        let knownIds = new Set(store.getState().pendingSignatures.keys());
+
+        return store.subscribe((state) => {
+            const ids = new Set(state.pendingSignatures.keys());
+            let hasNew = false;
+            for (const id of ids) {
+                if (!knownIds.has(id)) {
+                    hasNew = true;
+                    break;
+                }
+            }
+            knownIds = ids;
+            if (hasNew) void notifyHaptic();
+        });
+    }, []);
+}

--- a/apps/wallet/app/routes/__root.tsx
+++ b/apps/wallet/app/routes/__root.tsx
@@ -10,6 +10,7 @@ import { FullScreenGate } from "@/module/common/component/FullScreenGate";
 import { ModalOutlet } from "@/module/common/component/ModalOutlet";
 import { RootProvider } from "@/module/common/provider/RootProvider";
 import { TargetSignatureModal } from "@/module/pairing/component/TargetSignatureModal";
+import { useSignatureRequestHaptics } from "@/module/pairing/hook/useSignatureRequestHaptics";
 import { VersionGate } from "@/module/version";
 // Import open panel to ensure it's initialized
 import "@frak-labs/wallet-shared";
@@ -32,6 +33,7 @@ export const Route = createRootRoute({
  */
 function RootComponent() {
     useHardwareBack();
+    useSignatureRequestHaptics();
 
     // Pre-warm modal-only lazy chunks during browser idle so the first open
     // of Keypass / MoneriumBankFlow / ExplorerDetail / etc. resolves from a

--- a/apps/wallet/app/utils/haptics.ts
+++ b/apps/wallet/app/utils/haptics.ts
@@ -1,0 +1,58 @@
+import { IS_TAURI } from "@frak-labs/app-essentials/utils/platform";
+import { recordError } from "@frak-labs/wallet-shared";
+
+/**
+ * Cross-platform haptic feedback.
+ *
+ * On the Tauri mobile shell we use the native haptics engine
+ * (`@tauri-apps/plugin-haptics`), which drives the Taptic Engine on iOS and
+ * the vibrator on Android — more reliable than raw duration-based vibration.
+ * On the web (regular browser / PWA) we fall back to `navigator.vibrate`,
+ * which is supported on Android Chrome but is a no-op on iOS Safari.
+ *
+ * The module import is lazy and gated on `IS_TAURI` so the `@tauri-apps`
+ * dependency is tree-shaken out of the web bundle.
+ */
+
+let hapticsModulePromise: Promise<
+    typeof import("@tauri-apps/plugin-haptics") | null
+> | null = null;
+
+function getHapticsModule() {
+    if (!IS_TAURI) return Promise.resolve(null);
+
+    if (!hapticsModulePromise) {
+        hapticsModulePromise = import("@tauri-apps/plugin-haptics").catch(
+            (error) => {
+                recordError(error, { source: "haptics" });
+                return null;
+            }
+        );
+    }
+
+    return hapticsModulePromise;
+}
+
+/**
+ * Fire a short "notification" haptic, e.g. when a new signature request
+ * arrives from a paired device. Best-effort: never throws.
+ *
+ * @param webFallbackMs - Vibration duration used on the web fallback path.
+ */
+export async function notifyHaptic(webFallbackMs = 50): Promise<void> {
+    const module = await getHapticsModule();
+
+    if (!module) {
+        // Web fallback — Android Chrome only, silently ignored elsewhere.
+        if (typeof navigator !== "undefined") {
+            navigator.vibrate?.(webFallbackMs);
+        }
+        return;
+    }
+
+    try {
+        await module.notificationFeedback("warning");
+    } catch (error) {
+        recordError(error, { source: "haptics" });
+    }
+}

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -66,6 +66,7 @@
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-fs": "^2.5.1",
+    "@tauri-apps/plugin-haptics": "^2.3.2",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/apps/wallet/src-tauri/Cargo.lock
+++ b/apps/wallet/src-tauri/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "tauri-plugin-frak-updater",
  "tauri-plugin-frak-webauthn",
  "tauri-plugin-fs",
+ "tauri-plugin-haptics",
  "tauri-plugin-install-referrer",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -910,7 +911,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1121,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2330,7 +2331,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2666,7 +2667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3274,7 +3275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3605,7 +3606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4076,6 +4077,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-haptics"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b167d598ada05c599f4460595108c8d1aa636030a97d19796c1bcda97d881d"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-install-referrer"
 version = "0.1.0"
 dependencies = [
@@ -4272,7 +4287,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4648,7 +4663,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4688,7 +4703,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5188,7 +5203,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/wallet/src-tauri/Cargo.toml
+++ b/apps/wallet/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri = { version = "2.11", features = [] }
 tauri-plugin-log = "2.8.0"
 tauri-plugin-safe-area-insets = "0.1.0"
 tauri-plugin-biometric = "2"
+tauri-plugin-haptics = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-app-settings = { path = "plugins/tauri-plugin-app-settings" }

--- a/apps/wallet/src-tauri/capabilities/default.json
+++ b/apps/wallet/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
         "log:default",
         "safe-area-insets:default",
         "biometric:default",
+        "haptics:default",
         "frak-firebase:default",
         "deep-link:default",
         "opener:default",

--- a/apps/wallet/src-tauri/src/lib.rs
+++ b/apps/wallet/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
     {
         builder = builder
             .plugin(tauri_plugin_biometric::init())
+            .plugin(tauri_plugin_haptics::init())
             // tauri_plugin_frak_firebase moved above — registered before any
             // other mobile plugin so it can capture their setup crashes.
             .plugin(tauri_plugin_app_settings::init())

--- a/bun.lock
+++ b/bun.lock
@@ -214,7 +214,7 @@
     },
     "apps/wallet": {
       "name": "@frak-labs/nexus-wallet",
-      "version": "1.0.76",
+      "version": "1.0.77",
       "dependencies": {
         "@frak-labs/app-essentials": "workspace:*",
         "@frak-labs/client": "workspace:*",
@@ -233,6 +233,7 @@
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
         "@tauri-apps/plugin-fs": "^2.5.1",
+        "@tauri-apps/plugin-haptics": "^2.3.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "i18next": "^26.0.3",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -1963,6 +1964,8 @@
     "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
 
     "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ=="],
+
+    "@tauri-apps/plugin-haptics": ["@tauri-apps/plugin-haptics@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-TqvBR5JoPodDQWPXsNymmyqp37dOpunZOdVVbx5xOAxki7rVwiCMvoEPdtJQNIrU+dQDfkQYZ2oDBVOu4hf+ig=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 

--- a/packages/wallet-shared/src/common/analytics/events/diagnostics.ts
+++ b/packages/wallet-shared/src/common/analytics/events/diagnostics.ts
@@ -14,6 +14,7 @@ export type AppErrorSource =
     | "react_router"
     | "deep_link"
     | "biometrics"
+    | "haptics"
     | "service_worker"
     | "tokens_send"
     | "monerium_callback"


### PR DESCRIPTION
## What

Adds a small vibration when the wallet receives a new pairing **signature request**, on both web and mobile.

## How

- **Plugin**: adds the official [`@tauri-apps/plugin-haptics`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/haptics) (`tauri-plugin-haptics` v2.3.2, MIT/Apache-2.0 — same org/version line as the existing `biometric`/`deep-link`/`opener` plugins). Registered in the mobile Tauri builder with the `haptics:default` capability.
- **Helper** (`app/utils/haptics.ts`): `notifyHaptic()` calls native `notificationFeedback("warning")` on Tauri (iOS Taptic Engine / Android vibrator), falling back to `navigator.vibrate()` on web (Android Chrome; no-op on iOS Safari). The `@tauri-apps` import is lazy and gated on `IS_TAURI` so it's tree-shaken out of the web bundle — same pattern as `biometrics.ts`.
- **Trigger** (`useSignatureRequestHaptics` hook, mounted once at the app root): subscribes directly to the target pairing client store and buzzes on newly-added signature IDs. Single source of truth, fires exactly once per arrival regardless of mounted UI. Requests already pending when the subscription attaches are seeded as known and don't buzz.
- Adds `"haptics"` to `AppErrorSource` for error reporting.

## Notes

- Haptics stays in the wallet package (not `wallet-shared` / SDK) so shared/SDK consumers don't pull in the Tauri-only dependency.
- Typecheck + lint pass. Not verified against a full mobile build — worth a `tauri:ios:dev` / `tauri:android:dev` run to confirm the native plugin compiles.
