### PR TITLE
feat: reward breakdown in sharing FAQ

### DIFF
--- a/.changeset/sharing-faq-reward-breakdown.md
+++ b/.changeset/sharing-faq-reward-breakdown.md
@@ -1,0 +1,5 @@
+---
+"@frak-labs/core-sdk": minor
+---
+
+Expose the raw per-audience rewards on `selectBestReward` / `BestReward`. The result now carries `referrerReward`, `refereeReward`, and the unformatted `minPurchaseValue` alongside the existing formatted fields, so surfaces can render a full reward breakdown (tier rows, percentage worked-examples) instead of just the headline amount.

--- a/apps/listener/app/module/sharing/component/SharingPage/index.tsx
+++ b/apps/listener/app/module/sharing/component/SharingPage/index.tsx
@@ -224,6 +224,11 @@ export function ListenerSharingPage() {
             rewardType={reward?.payoutType}
             minPurchaseAmount={reward?.minPurchaseAmount}
             lockupDurationDays={reward?.lockupDurationDays}
+            rewardBreakdown={{
+                referrer: reward?.referrerReward,
+                referee: reward?.refereeReward,
+                minPurchaseValue: reward?.minPurchaseValue,
+            }}
             showConfirmation={showConfirmation}
             onShare={handleShare}
             onCopy={handleCopy}

--- a/apps/wallet/app/routes/sharing.tsx
+++ b/apps/wallet/app/routes/sharing.tsx
@@ -317,6 +317,11 @@ function WalletSharingPage() {
             rewardType={reward?.payoutType}
             minPurchaseAmount={reward?.minPurchaseAmount}
             lockupDurationDays={reward?.lockupDurationDays}
+            rewardBreakdown={{
+                referrer: reward?.referrerReward,
+                referee: reward?.refereeReward,
+                minPurchaseValue: reward?.minPurchaseValue,
+            }}
             canShare={canShare}
             showConfirmation={showConfirmation}
             onShare={handleShare}

--- a/packages/wallet-shared/src/i18n/locales/en/customized.json
+++ b/packages/wallet-shared/src/i18n/locales/en/customized.json
@@ -86,7 +86,16 @@
                 "q4": "Can my friends also become \"ambassadors\"?",
                 "a4": "Yes, everyone can create their own sharing link and become an ambassador too.",
                 "q5": "Why do brands use Frak?",
-                "a5": "Frak enables brands to reward their community for word-of-mouth, in a transparent and decentralized way."
+                "a5": "Frak enables brands to reward their community for word-of-mouth, in a transparent and decentralized way.",
+                "q6": "How is my reward calculated?",
+                "a6": "The amount shown is the maximum reward you can earn. Depending on the brand, your reward may be a fixed amount, a percentage of the purchase, or vary by tier based on the order amount.",
+                "reward": {
+                    "referrerLabel": "Reward as an ambassador",
+                    "refereeLabel": "Reward for your referee",
+                    "percentOfBasket": "{{percent}}% of basket",
+                    "percentExample": "e.g. {{reward}} for a {{basket}} order",
+                    "tierAndAbove": "{{min}} and above"
+                }
             },
             "legal": {
                 "help": "Help",

--- a/packages/wallet-shared/src/i18n/locales/fr/customized.json
+++ b/packages/wallet-shared/src/i18n/locales/fr/customized.json
@@ -87,7 +87,16 @@
                 "q4": "Est-ce que mes proches peuvent eux aussi devenir \"ambassadeur\" ?",
                 "a4": "Oui, chaque personne peut créer son propre lien de partage et devenir ambassadeur à son tour.",
                 "q5": "Pourquoi les marques utilisent-elles Frak ?",
-                "a5": "Frak permet aux marques de récompenser leur communauté pour le bouche-à-oreille, de manière transparente et décentralisée."
+                "a5": "Frak permet aux marques de récompenser leur communauté pour le bouche-à-oreille, de manière transparente et décentralisée.",
+                "q6": "Comment est calculée ma récompense ?",
+                "a6": "Le montant affiché correspond à la récompense maximale possible. Selon la marque, votre récompense peut être un montant fixe, un pourcentage de l'achat, ou varier selon des paliers en fonction du montant de la commande.",
+                "reward": {
+                    "referrerLabel": "Récompense en tant que parrain",
+                    "refereeLabel": "Récompense en tant que filleul",
+                    "percentOfBasket": "{{percent}}% du panier",
+                    "percentExample": "Ex. {{reward}} pour {{basket}} d'achat",
+                    "tierAndAbove": "{{min}} et plus"
+                }
             },
             "legal": {
                 "help": "Aide",

--- a/packages/wallet-shared/src/sharing/component/SharingPage/RewardBreakdown.test.tsx
+++ b/packages/wallet-shared/src/sharing/component/SharingPage/RewardBreakdown.test.tsx
@@ -1,0 +1,153 @@
+import type { EstimatedReward } from "@frak-labs/core-sdk";
+import { formatAmount } from "@frak-labs/core-sdk";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RewardBreakdown } from "./RewardBreakdown";
+
+// Deterministic stand-in for the merchant-aware `t`: echoes the interpolated
+// values so assertions read against concrete text instead of raw keys.
+const t = (key: string, opts?: Record<string, unknown>): string => {
+    switch (key) {
+        case "sdk.sharingPage.faq.reward.referrerLabel":
+            return "Reward as ambassador";
+        case "sdk.sharingPage.faq.reward.refereeLabel":
+            return "Reward for referee";
+        case "sdk.sharingPage.faq.reward.percentOfBasket":
+            return `${opts?.percent}% of basket`;
+        case "sdk.sharingPage.faq.reward.percentExample":
+            return `e.g. ${opts?.reward} for ${opts?.basket}`;
+        case "sdk.sharingPage.faq.reward.tierAndAbove":
+            return `${opts?.min} and above`;
+        default:
+            return key;
+    }
+};
+
+// `formatAmount` uses a narrow no-break space; Testing Library normalizes DOM
+// whitespace to plain spaces, so align expected strings the same way.
+const fmt = (eur: number) => formatAmount(eur).replace(/\s/g, " ");
+
+const tokenAmount = (eur: number) => ({
+    amount: eur,
+    eurAmount: eur,
+    usdAmount: eur,
+    gbpAmount: eur,
+});
+
+const fixed = (eur: number): EstimatedReward => ({
+    payoutType: "fixed",
+    amount: tokenAmount(eur),
+});
+
+const percentage = (percent: number): EstimatedReward => ({
+    payoutType: "percentage",
+    percent,
+    percentOf: "purchase_amount",
+});
+
+const tiered = (
+    tiers: Extract<EstimatedReward, { payoutType: "tiered" }>["tiers"]
+): EstimatedReward => ({
+    payoutType: "tiered",
+    tierField: "purchase_amount",
+    tiers,
+});
+
+describe("RewardBreakdown", () => {
+    it("renders tiered rows for both audiences", () => {
+        const referrer = tiered([
+            { minValue: 0, maxValue: 50, amount: tokenAmount(8) },
+            { minValue: 50, amount: tokenAmount(18) },
+        ]);
+        const referee = tiered([
+            { minValue: 0, maxValue: 50, amount: tokenAmount(2) },
+            { minValue: 50, amount: tokenAmount(5) },
+        ]);
+
+        render(<RewardBreakdown referrer={referrer} referee={referee} t={t} />);
+
+        expect(screen.getByText("Reward as ambassador")).toBeInTheDocument();
+        expect(screen.getByText("Reward for referee")).toBeInTheDocument();
+
+        // Per-audience amounts (unique) render as formatted values.
+        expect(screen.getByText(fmt(8))).toBeInTheDocument();
+        expect(screen.getByText(fmt(18))).toBeInTheDocument();
+        expect(screen.getByText(fmt(2))).toBeInTheDocument();
+        expect(screen.getByText(fmt(5))).toBeInTheDocument();
+
+        // Bounded range + open-ended top tier appear once per audience.
+        expect(screen.getAllByText(`0\u2013${fmt(50)}`)).toHaveLength(2);
+        expect(screen.getAllByText(`${fmt(50)} and above`)).toHaveLength(2);
+    });
+
+    it("renders a percentage reward with a worked example at the 100 reference basket", () => {
+        render(<RewardBreakdown referrer={percentage(10)} t={t} />);
+
+        expect(screen.getByText("10% of basket")).toBeInTheDocument();
+        expect(
+            screen.getByText(`e.g. ${fmt(10)} for ${fmt(100)}`)
+        ).toBeInTheDocument();
+    });
+
+    it("bumps the example basket to the campaign minimum when higher", () => {
+        render(
+            <RewardBreakdown
+                referrer={percentage(10)}
+                minPurchaseValue={150}
+                t={t}
+            />
+        );
+
+        expect(
+            screen.getByText(`e.g. ${fmt(15)} for ${fmt(150)}`)
+        ).toBeInTheDocument();
+    });
+
+    it("renders percent tiers with a per-tier example", () => {
+        render(
+            <RewardBreakdown
+                referrer={tiered([{ minValue: 0, maxValue: 100, percent: 5 }])}
+                t={t}
+            />
+        );
+
+        expect(screen.getByText("5% of basket")).toBeInTheDocument();
+        expect(
+            screen.getByText(`e.g. ${fmt(5)} for ${fmt(100)}`)
+        ).toBeInTheDocument();
+    });
+
+    it("shows only the audience that has a percentage/tiered reward", () => {
+        render(
+            <RewardBreakdown
+                referrer={percentage(12)}
+                referee={fixed(3)}
+                t={t}
+            />
+        );
+
+        expect(screen.getByText("Reward as ambassador")).toBeInTheDocument();
+        expect(
+            screen.queryByText("Reward for referee")
+        ).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when both rewards are fixed", () => {
+        const { container } = render(
+            <RewardBreakdown referrer={fixed(5)} referee={fixed(2)} t={t} />
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing for a tiered reward with no tiers", () => {
+        const { container } = render(
+            <RewardBreakdown referrer={tiered([])} t={t} />
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when no rewards are provided", () => {
+        const { container } = render(<RewardBreakdown t={t} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/packages/wallet-shared/src/sharing/component/SharingPage/RewardBreakdown.tsx
+++ b/packages/wallet-shared/src/sharing/component/SharingPage/RewardBreakdown.tsx
@@ -1,0 +1,172 @@
+import type { EstimatedReward } from "@frak-labs/core-sdk";
+import { formatAmount } from "@frak-labs/core-sdk";
+import {
+    buildPercentageExample,
+    buildTierExample,
+    type RewardExample,
+} from "@frak-labs/core-sdk/rewards";
+import * as styles from "./sharingPage.css";
+
+type TieredReward = Extract<EstimatedReward, { payoutType: "tiered" }>;
+type RewardTier = TieredReward["tiers"][number];
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+/**
+ * Per-audience reward detail rendered inside the "How is my reward calculated?"
+ * FAQ answer. Mirrors the explorer's campaign card: tier rows for tiered
+ * rewards, a "X% of basket" line with a worked example for percentage rewards.
+ * Fixed rewards carry no breakdown and are skipped.
+ */
+export function RewardBreakdown({
+    referrer,
+    referee,
+    minPurchaseValue,
+    t,
+}: {
+    referrer?: EstimatedReward;
+    referee?: EstimatedReward;
+    minPurchaseValue?: number;
+    t: Translate;
+}) {
+    const hasReferrer = hasBreakdown(referrer);
+    const hasReferee = hasBreakdown(referee);
+    if (!(hasReferrer || hasReferee)) return null;
+
+    return (
+        <div className={styles.rewardBreakdown}>
+            {hasReferrer && referrer && (
+                <RewardBlock
+                    label={t("sdk.sharingPage.faq.reward.referrerLabel")}
+                    reward={referrer}
+                    minPurchaseValue={minPurchaseValue}
+                    t={t}
+                />
+            )}
+            {hasReferee && referee && (
+                <RewardBlock
+                    label={t("sdk.sharingPage.faq.reward.refereeLabel")}
+                    reward={referee}
+                    minPurchaseValue={minPurchaseValue}
+                    t={t}
+                />
+            )}
+        </div>
+    );
+}
+
+/** Whether a reward is worth a breakdown (percentage, or a tiered reward that
+ * actually carries tiers — an empty tier list would render a bare label). */
+function hasBreakdown(reward?: EstimatedReward): boolean {
+    if (reward?.payoutType === "percentage") return true;
+    if (reward?.payoutType === "tiered") return reward.tiers.length > 0;
+    return false;
+}
+
+function RewardBlock({
+    label,
+    reward,
+    minPurchaseValue,
+    t,
+}: {
+    label: string;
+    reward: EstimatedReward;
+    minPurchaseValue?: number;
+    t: Translate;
+}) {
+    return (
+        <div className={styles.rewardBlock}>
+            <span className={styles.rewardBlockLabel}>{label}</span>
+            {reward.payoutType === "tiered"
+                ? reward.tiers.map((tier) => (
+                      <TierRow key={tierKey(tier)} tier={tier} t={t} />
+                  ))
+                : reward.payoutType === "percentage" && (
+                      <PercentageRow
+                          reward={reward}
+                          minPurchaseValue={minPurchaseValue}
+                          t={t}
+                      />
+                  )}
+        </div>
+    );
+}
+
+function TierRow({ tier, t }: { tier: RewardTier; t: Translate }) {
+    const range =
+        tier.maxValue == null
+            ? t("sdk.sharingPage.faq.reward.tierAndAbove", {
+                  min: formatAmount(tier.minValue),
+              })
+            : `${tier.minValue}–${formatAmount(tier.maxValue)}`;
+
+    if ("amount" in tier) {
+        return (
+            <div className={styles.rewardRow}>
+                <span>{range}</span>
+                <span className={styles.rewardRowValue}>
+                    {formatAmount(tier.amount.eurAmount)}
+                </span>
+            </div>
+        );
+    }
+
+    const example = buildTierExample(
+        tier.percent,
+        tier.minValue,
+        tier.maxValue
+    );
+    return (
+        <div className={styles.rewardRow}>
+            <span>{range}</span>
+            <span className={styles.rewardRowValue}>
+                {t("sdk.sharingPage.faq.reward.percentOfBasket", {
+                    percent: tier.percent,
+                })}
+                {example && <ExampleText example={example} t={t} />}
+            </span>
+        </div>
+    );
+}
+
+function PercentageRow({
+    reward,
+    minPurchaseValue,
+    t,
+}: {
+    reward: Extract<EstimatedReward, { payoutType: "percentage" }>;
+    minPurchaseValue?: number;
+    t: Translate;
+}) {
+    const example = buildPercentageExample(reward, minPurchaseValue);
+    return (
+        <div className={styles.rewardRow}>
+            <span>
+                {t("sdk.sharingPage.faq.reward.percentOfBasket", {
+                    percent: reward.percent,
+                })}
+            </span>
+            {example && (
+                <span className={styles.rewardRowValue}>
+                    <ExampleText example={example} t={t} />
+                </span>
+            )}
+        </div>
+    );
+}
+
+function ExampleText({ example, t }: { example: RewardExample; t: Translate }) {
+    return (
+        <span className={styles.rewardExample}>
+            {t("sdk.sharingPage.faq.reward.percentExample", {
+                reward: formatAmount(example.reward),
+                basket: formatAmount(example.basket),
+            })}
+        </span>
+    );
+}
+
+function tierKey(tier: RewardTier): string {
+    const value = "amount" in tier ? tier.amount.eurAmount : tier.percent;
+    return `${tier.minValue}-${tier.maxValue ?? "inf"}-${value}`;
+}

--- a/packages/wallet-shared/src/sharing/component/SharingPage/index.tsx
+++ b/packages/wallet-shared/src/sharing/component/SharingPage/index.tsx
@@ -24,6 +24,7 @@ import { ExternalLink } from "../../../common/component/ExternalLink";
 import { MerchantLogo } from "../MerchantLogo";
 import { PostShareConfirmation } from "../PostShareConfirmation";
 import { overlay } from "../shared.css";
+import { RewardBreakdown } from "./RewardBreakdown";
 import * as styles from "./sharingPage.css";
 
 export type SharingPageProps = {
@@ -82,6 +83,16 @@ export type SharingPageProps = {
      * line stating when earnings become available.
      */
     lockupDurationDays?: number;
+    /**
+     * Raw per-audience reward details used to render the tier/percentage
+     * breakdown inside the "How is my reward calculated?" FAQ answer. When the
+     * rewards are fixed (or absent), no breakdown is shown.
+     */
+    rewardBreakdown?: {
+        referrer?: EstimatedReward;
+        referee?: EstimatedReward;
+        minPurchaseValue?: number;
+    };
     /**
      * Whether the Web Share API is available in the current browser.
      * When false, the share button is hidden and copy is the only option.
@@ -142,6 +153,7 @@ export function SharingPage({
     rewardType,
     minPurchaseAmount,
     lockupDurationDays,
+    rewardBreakdown,
     canShare = true,
     showConfirmation,
     onShare,
@@ -357,7 +369,7 @@ export function SharingPage({
                             collapsible
                             className={styles.faqList}
                         >
-                            {[1, 2, 3, 4, 5].map((i) => (
+                            {[1, 2, 3, 4, 5, 6].map((i) => (
                                 <AccordionItem
                                     key={`faq-${i}`}
                                     value={`faq-${i}`}
@@ -379,6 +391,20 @@ export function SharingPage({
                                     <AccordionContent>
                                         <div className={styles.faqContent}>
                                             {t(`sdk.sharingPage.faq.a${i}`)}
+                                            {i === 6 && rewardBreakdown && (
+                                                <RewardBreakdown
+                                                    referrer={
+                                                        rewardBreakdown.referrer
+                                                    }
+                                                    referee={
+                                                        rewardBreakdown.referee
+                                                    }
+                                                    minPurchaseValue={
+                                                        rewardBreakdown.minPurchaseValue
+                                                    }
+                                                    t={t}
+                                                />
+                                            )}
                                         </div>
                                     </AccordionContent>
                                 </AccordionItem>

--- a/packages/wallet-shared/src/sharing/component/SharingPage/sharingPage.css.ts
+++ b/packages/wallet-shared/src/sharing/component/SharingPage/sharingPage.css.ts
@@ -393,3 +393,46 @@ export const copyButton = style({
         },
     },
 });
+
+export const rewardBreakdown = style({
+    display: "flex",
+    flexDirection: "column",
+    gap: alias.spacing.m,
+    marginTop: alias.spacing.s,
+    paddingTop: alias.spacing.m,
+    borderTop: `1px solid ${vars.border.subtle}`,
+});
+
+export const rewardBlock = style({
+    display: "flex",
+    flexDirection: "column",
+    gap: alias.spacing.xs,
+});
+
+export const rewardBlockLabel = style({
+    fontSize: fontSize.s,
+    fontWeight: 700,
+    color: vars.text.primary,
+});
+
+export const rewardRow = style({
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: alias.spacing.m,
+    color: vars.text.secondary,
+});
+
+export const rewardRowValue = style({
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    flexShrink: 0,
+    fontWeight: 500,
+    color: vars.text.primary,
+});
+
+export const rewardExample = style({
+    fontSize: fontSize.xs,
+    color: vars.text.tertiary,
+});

--- a/packages/wallet-shared/src/types/i18n/resources.d.ts
+++ b/packages/wallet-shared/src/types/i18n/resources.d.ts
@@ -78,11 +78,20 @@ export default interface Resources {
           "a3": "Your earnings are credited as soon as a purchase is confirmed through your sharing link.",
           "a4": "Yes, everyone can create their own sharing link and become an ambassador too.",
           "a5": "Frak enables brands to reward their community for word-of-mouth, in a transparent and decentralized way.",
+          "a6": "The amount shown is the maximum reward you can earn. Depending on the brand, your reward may be a fixed amount, a percentage of the purchase, or vary by tier based on the order amount.",
           "q1": "Who can become an \"ambassador\"?",
           "q2": "How much can I earn?",
           "q3": "When do I get paid?",
           "q4": "Can my friends also become \"ambassadors\"?",
           "q5": "Why do brands use Frak?",
+          "q6": "How is my reward calculated?",
+          "reward": {
+            "percentExample": "e.g. {{reward}} for a {{basket}} order",
+            "percentOfBasket": "{{percent}}% of basket",
+            "refereeLabel": "Reward for your referee",
+            "referrerLabel": "Reward as an ambassador",
+            "tierAndAbove": "{{min}} and above"
+          },
           "title": "Frequently asked questions"
         },
         "legal": {

--- a/sdk/core/src/rewards/select.test.ts
+++ b/sdk/core/src/rewards/select.test.ts
@@ -278,4 +278,52 @@ describe("selectBestReward", () => {
         );
         expect(best?.lockupDurationDays).toBeUndefined();
     });
+
+    it("surfaces the raw referrer and referee rewards for the breakdown", () => {
+        const referrer = uncappedPercentage(10);
+        const referee = fixedReward(3);
+        const best = selectBestReward(
+            [campaign({ id: "c", referrer, referee })],
+            { now: NOW }
+        );
+        expect(best?.referrerReward).toEqual(referrer);
+        expect(best?.refereeReward).toEqual(referee);
+    });
+
+    it("leaves the referee reward undefined when the campaign has none", () => {
+        const best = selectBestReward(
+            [campaign({ id: "c", referrer: fixedReward(50) })],
+            { now: NOW }
+        );
+        expect(best?.refereeReward).toBeUndefined();
+    });
+
+    it("surfaces the raw minimum purchase value alongside the formatted string", () => {
+        const best = selectBestReward(
+            [
+                campaign({
+                    id: "c",
+                    referrer: fixedReward(50),
+                    conditions: [
+                        {
+                            field: "purchase.amount",
+                            operator: "gte",
+                            value: 25,
+                        },
+                    ],
+                }),
+            ],
+            { now: NOW }
+        );
+        expect(best?.minPurchaseValue).toBe(25);
+        expect(best?.minPurchaseAmount).toContain("25");
+    });
+
+    it("leaves minPurchaseValue undefined when the campaign has no minimum", () => {
+        const best = selectBestReward(
+            [campaign({ id: "c", referrer: fixedReward(50) })],
+            { now: NOW }
+        );
+        expect(best?.minPurchaseValue).toBeUndefined();
+    });
 });

--- a/sdk/core/src/rewards/select.ts
+++ b/sdk/core/src/rewards/select.ts
@@ -136,6 +136,18 @@ export type BestReward = {
      * the campaign has no lockup.
      */
     lockupDurationDays?: number;
+    /**
+     * Raw referrer/referee rewards of the selected campaign, surfaced so
+     * consumers can render the full per-audience breakdown (tier rows,
+     * percentage examples) rather than only the headline number.
+     */
+    referrerReward?: EstimatedReward;
+    refereeReward?: EstimatedReward;
+    /**
+     * Raw minimum purchase value (unformatted), used to build percentage
+     * worked-examples consistent with the campaign's gating.
+     */
+    minPurchaseValue?: number;
 };
 
 /**
@@ -178,6 +190,9 @@ export function selectBestReward(
         payoutType: reward.payoutType,
         minPurchaseAmount,
         lockupDurationDays,
+        referrerReward: selected.campaign.referrer,
+        refereeReward: selected.campaign.referee,
+        minPurchaseValue: minPurchase ?? undefined,
     };
 }
 


### PR DESCRIPTION
## What

Adds a per-audience **reward breakdown** to the sharing page FAQ. Under _"Comment est calculée ma récompense ?"_ (q6) the real campaign reward now renders like the wallet explorer: tier rows for tiered rewards, and `X% du panier` + a worked example for percentage rewards — for both the ambassador (parrain) and referee (filleul).

## Commits

- **feat(core-sdk): expose raw referrer/referee rewards and min purchase on selectBestReward**
  `BestReward` now carries `referrerReward`, `refereeReward`, and the unformatted `minPurchaseValue` alongside the existing formatted fields, so surfaces can render a full breakdown instead of just the headline amount. Additive, backwards-compatible.
- **feat(wallet-shared): add reward breakdown to sharing FAQ**
  New `RewardBreakdown` component (reuses the SDK's `buildTierExample` / `buildPercentageExample` / `formatAmount`), rendered inside the q6 accordion; wired through both the listener and wallet sharing pages. q6/a6 copy reworded to stay accurate for fixed rewards, plus regenerated i18n types and theme-var-only styles.

## Release (changesets)

Includes a changeset — `@frak-labs/core-sdk` **minor** (→ `@frak-labs/react-sdk` minor via `linked`, `@frak-labs/components` patch). The consuming apps and `wallet-shared` are private/ignored, no bump. The Version Packages PR handles publishing after merge.

## Tests

- `sdk/core` reward suite: 58 pass (5 new `BestReward` field cases)
- `wallet-shared` `RewardBreakdown`: 8 pass (tiered / percentage / min-basket / fixed-skip / empty-tiers / no-reward)

## Flow / follow-ups

- After merge to `main`, **back-merge `main → dev`** (also reconciles the release commits main is ahead on).
- The `infra/gcp-tunnel.sh` health-check is intentionally **not** in this PR — it lands on **dev only**.
- Filed **FRA-260**: `estimated-rewards` caches an empty `[]` on fetch error and hides rewards for 5 min (pre-existing footgun, separate fix).
