### PR TITLE
fix(shopify): keep server-only onboarding fetchers out of client bundle

### DIFF
--- a/apps/shopify/app/routes/app.tsx
+++ b/apps/shopify/app/routes/app.tsx
@@ -18,10 +18,10 @@ import {
 } from "app/services.server/theme";
 import { shouldShowOutletSkeleton } from "app/utils/navigationLoading";
 import {
-    fetchAllOnboardingData,
     type OnboardingStepData,
     validateCompleteOnboarding,
 } from "app/utils/onboarding";
+import { fetchAllOnboardingData } from "app/utils/onboarding.server";
 import { type ReactNode, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";

--- a/apps/shopify/app/utils/onboarding.server.ts
+++ b/apps/shopify/app/utils/onboarding.server.ts
@@ -1,0 +1,157 @@
+import { getFrakWebookStatus } from "app/services.server/backendMerchant";
+import { log } from "app/services.server/logger";
+import { firstProductPublished } from "app/services.server/shop";
+import {
+    doesThemeHasFrakActivated,
+    doesThemeHasFrakBanner,
+    doesThemeHasFrakButton,
+    getMainThemeId,
+} from "app/services.server/theme";
+import { getWebhooks } from "app/services.server/webhook";
+import { getWebPixel } from "app/services.server/webPixel";
+import type { AuthenticatedContext } from "app/types/context";
+import { resolveMerchantId } from "../services.server/merchant";
+import type { OnboardingStepData } from "./onboarding";
+
+/**
+ * Data fetchers for each onboarding step.
+ *
+ * Server-only: these pull in `app/services.server/*` (Shopify Admin GraphQL +
+ * the pino/AsyncLocalStorage logger). They live in a `.server`-suffixed module
+ * so they can never leak into the client bundle — importing them from a
+ * client-reachable module would ship `node:async_hooks` to the browser and
+ * crash hydration.
+ */
+const stepDataFetchers = {
+    1: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
+        try {
+            const merchantId = await resolveMerchantId(context);
+            return { merchantId };
+        } catch (e) {
+            log.warn({ err: e }, "onboarding: error resolving merchantId");
+            return {};
+        }
+    },
+    2: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
+        try {
+            const webPixel = await getWebPixel(context);
+            return { webPixel };
+        } catch (error) {
+            log.error({ err: error }, "onboarding: error fetching web pixel");
+            return {};
+        }
+    },
+
+    3: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
+        try {
+            const webhooks = await getWebhooks(context);
+            return { webhooks };
+        } catch (error) {
+            log.error(
+                { err: error },
+                "onboarding: error fetching shopify webhooks"
+            );
+            return {};
+        }
+    },
+
+    4: async (
+        context: AuthenticatedContext,
+        request: Request
+    ): Promise<OnboardingStepData> => {
+        try {
+            const merchantId = await resolveMerchantId(context);
+            const frakWebhook = await getFrakWebookStatus(context, request);
+            return { frakWebhook, merchantId };
+        } catch (error) {
+            log.error(
+                { err: error },
+                "onboarding: error fetching frak webhook"
+            );
+            return {};
+        }
+    },
+
+    5: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
+        try {
+            const [isThemeHasFrakActivated, theme] = await Promise.all([
+                doesThemeHasFrakActivated(context),
+                getMainThemeId(context),
+            ]);
+            return { isThemeHasFrakActivated, theme };
+        } catch (error) {
+            log.error({ err: error }, "onboarding: error fetching theme data");
+            return {};
+        }
+    },
+
+    6: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
+        try {
+            const [isThemeHasFrakButton, firstProduct] = await Promise.all([
+                doesThemeHasFrakButton(context),
+                firstProductPublished(context),
+            ]);
+            return { isThemeHasFrakButton, firstProduct };
+        } catch (error) {
+            log.error({ err: error }, "onboarding: error fetching button data");
+            return {};
+        }
+    },
+
+    7: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
+        try {
+            const isThemeHasFrakBanner = await doesThemeHasFrakBanner(context);
+            return { isThemeHasFrakBanner };
+        } catch (error) {
+            log.error({ err: error }, "onboarding: error fetching banner data");
+            return {};
+        }
+    },
+};
+
+/**
+ * Fetches all data needed for comprehensive onboarding validation
+ * @param context - The authenticated context
+ * @returns Complete onboarding data for all steps
+ */
+export async function fetchAllOnboardingData(
+    context: AuthenticatedContext,
+    request: Request
+): Promise<OnboardingStepData> {
+    try {
+        // Fetch all data in parallel for efficiency
+        const [
+            shopInfoData,
+            webPixelData,
+            webhookData,
+            frakWebhookData,
+            themeData,
+            buttonData,
+            bannerData,
+        ] = await Promise.all([
+            stepDataFetchers[1](context),
+            stepDataFetchers[2](context),
+            stepDataFetchers[3](context),
+            stepDataFetchers[4](context, request),
+            stepDataFetchers[5](context),
+            stepDataFetchers[6](context),
+            stepDataFetchers[7](context),
+        ]);
+        // Merge all data
+        return {
+            ...shopInfoData,
+            ...webPixelData,
+            ...webhookData,
+            ...frakWebhookData,
+            ...themeData,
+            ...buttonData,
+            ...bannerData,
+        };
+    } catch (error) {
+        log.error(
+            { err: error },
+            "onboarding: error fetching complete onboarding data"
+        );
+        return {};
+    }
+}

--- a/apps/shopify/app/utils/onboarding.ts
+++ b/apps/shopify/app/utils/onboarding.ts
@@ -1,26 +1,12 @@
-import { getFrakWebookStatus } from "app/services.server/backendMerchant";
-import { log } from "app/services.server/logger";
-import {
-    type FirstProductPublishedReturnType,
-    firstProductPublished,
-} from "app/services.server/shop";
-import {
-    doesThemeHasFrakActivated,
-    doesThemeHasFrakBanner,
-    doesThemeHasFrakButton,
-    type GetMainThemeIdReturnType,
-    getMainThemeId,
-} from "app/services.server/theme";
-import {
-    type GetWebhooksSubscriptionsReturnType,
-    getWebhooks,
-} from "app/services.server/webhook";
-import {
-    type GetWebPixelReturnType,
-    getWebPixel,
-} from "app/services.server/webPixel";
-import type { AuthenticatedContext } from "app/types/context";
-import { resolveMerchantId } from "../services.server/merchant";
+// NOTE: type-only imports — erased at build, so this module stays client-safe.
+// The server-only data fetchers (which pull in the pino/AsyncLocalStorage
+// logger + Admin GraphQL clients) live in `./onboarding.server`. Keep it that
+// way: importing a `.server` runtime binding here would ship `node:async_hooks`
+// to the browser and crash hydration (blank embedded app).
+import type { FirstProductPublishedReturnType } from "app/services.server/shop";
+import type { GetMainThemeIdReturnType } from "app/services.server/theme";
+import type { GetWebhooksSubscriptionsReturnType } from "app/services.server/webhook";
+import type { GetWebPixelReturnType } from "app/services.server/webPixel";
 
 export type OnboardingStepData = {
     webPixel?: GetWebPixelReturnType;
@@ -60,96 +46,6 @@ export const stepValidations: StepValidation = {
 export const MAX_STEP = Object.keys(stepValidations).length;
 
 /**
- * Data fetchers for each onboarding step
- */
-const stepDataFetchers = {
-    1: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
-        try {
-            const merchantId = await resolveMerchantId(context);
-            return { merchantId };
-        } catch (e) {
-            log.warn({ err: e }, "onboarding: error resolving merchantId");
-            return {};
-        }
-    },
-    2: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
-        try {
-            const webPixel = await getWebPixel(context);
-            return { webPixel };
-        } catch (error) {
-            log.error({ err: error }, "onboarding: error fetching web pixel");
-            return {};
-        }
-    },
-
-    3: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
-        try {
-            const webhooks = await getWebhooks(context);
-            return { webhooks };
-        } catch (error) {
-            log.error(
-                { err: error },
-                "onboarding: error fetching shopify webhooks"
-            );
-            return {};
-        }
-    },
-
-    4: async (
-        context: AuthenticatedContext,
-        request: Request
-    ): Promise<OnboardingStepData> => {
-        try {
-            const merchantId = await resolveMerchantId(context);
-            const frakWebhook = await getFrakWebookStatus(context, request);
-            return { frakWebhook, merchantId };
-        } catch (error) {
-            log.error(
-                { err: error },
-                "onboarding: error fetching frak webhook"
-            );
-            return {};
-        }
-    },
-
-    5: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
-        try {
-            const [isThemeHasFrakActivated, theme] = await Promise.all([
-                doesThemeHasFrakActivated(context),
-                getMainThemeId(context),
-            ]);
-            return { isThemeHasFrakActivated, theme };
-        } catch (error) {
-            log.error({ err: error }, "onboarding: error fetching theme data");
-            return {};
-        }
-    },
-
-    6: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
-        try {
-            const [isThemeHasFrakButton, firstProduct] = await Promise.all([
-                doesThemeHasFrakButton(context),
-                firstProductPublished(context),
-            ]);
-            return { isThemeHasFrakButton, firstProduct };
-        } catch (error) {
-            log.error({ err: error }, "onboarding: error fetching button data");
-            return {};
-        }
-    },
-
-    7: async (context: AuthenticatedContext): Promise<OnboardingStepData> => {
-        try {
-            const isThemeHasFrakBanner = await doesThemeHasFrakBanner(context);
-            return { isThemeHasFrakBanner };
-        } catch (error) {
-            log.error({ err: error }, "onboarding: error fetching banner data");
-            return {};
-        }
-    },
-};
-
-/**
  * Validates if a specific step is completed based on the provided data
  * @param step - The step number to validate
  * @param data - The onboarding step data
@@ -160,52 +56,6 @@ export function validateStep(step: number, data: OnboardingStepData): boolean {
     return validator ? !validator(data) : false;
 }
 
-/**
- * Fetches all data needed for comprehensive onboarding validation
- * @param context - The authenticated context
- * @returns Complete onboarding data for all steps
- */
-export async function fetchAllOnboardingData(
-    context: AuthenticatedContext,
-    request: Request
-): Promise<OnboardingStepData> {
-    try {
-        // Fetch all data in parallel for efficiency
-        const [
-            shopInfoData,
-            webPixelData,
-            webhookData,
-            frakWebhookData,
-            themeData,
-            buttonData,
-            bannerData,
-        ] = await Promise.all([
-            stepDataFetchers[1](context),
-            stepDataFetchers[2](context),
-            stepDataFetchers[3](context),
-            stepDataFetchers[4](context, request),
-            stepDataFetchers[5](context),
-            stepDataFetchers[6](context),
-            stepDataFetchers[7](context),
-        ]);
-        // Merge all data
-        return {
-            ...shopInfoData,
-            ...webPixelData,
-            ...webhookData,
-            ...frakWebhookData,
-            ...themeData,
-            ...buttonData,
-            ...bannerData,
-        };
-    } catch (error) {
-        log.error(
-            { err: error },
-            "onboarding: error fetching complete onboarding data"
-        );
-        return {};
-    }
-}
 /**
  * Backend / registration steps that always apply, regardless of theme:
  *  - Frak registration


### PR DESCRIPTION
`app/routes/app.tsx` uses `validateCompleteOnboarding` on the client and imported it from `app/utils/onboarding.ts`, which also pulled in `app/services.server/*` (the pino/AsyncLocalStorage logger + Admin GraphQL clients). That dragged the whole server graph into the client `onboarding` chunk, so the browser hit `new AsyncLocalStorage()` (node:async_hooks) and threw "AsyncLocalStorage is not a constructor", crashing hydration and leaving the embedded admin screens blank.

rolldown-vite does not enforce the `.server` module boundary that would normally fail this build, so the leak shipped silently to prod and staging.

Split the module:
- onboarding.server.ts: fetchAllOnboardingData + stepDataFetchers + all services.server runtime imports (server-only).
- onboarding.ts: client-safe validators/types only; service types are now erased `import type`.
- app.tsx imports fetchAllOnboardingData from onboarding.server.

Verified the rebuilt client bundle no longer contains AsyncLocalStorage, pino, drizzle, postgres, secrets, or any node: builtin import.