### PR TITLE
release: dev → main (mobile release lockfile sync)

### DIFF
--- a/.github/workflows/tauri-mobile-release.yml
+++ b/.github/workflows/tauri-mobile-release.yml
@@ -85,6 +85,9 @@ jobs:
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
 
+      - name: "🔒 Update lockfile"
+        run: bun install --lockfile-only
+
       - name: "📌 Create release PR"
         uses: peter-evans/create-pull-request@v8
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -226,7 +226,7 @@
     },
     "apps/wallet": {
       "name": "@frak-labs/nexus-wallet",
-      "version": "1.0.87",
+      "version": "1.0.89",
       "dependencies": {
         "@frak-labs/app-essentials": "workspace:*",
         "@frak-labs/client": "workspace:*",


### PR DESCRIPTION
## Summary

Release merge of `dev` into `main`. 1 commit, 2 files changed (+4 / -1).

Small follow-up release to #282 — CI hygiene only, no application code.

## Changes

### CI
- ci(wallet): update lockfile after mobile version sync

The mobile release workflow (`tauri-mobile-release.yml`) bumps `apps/wallet/package.json` but never refreshed `bun.lock`, so the workspace version entry in the lockfile drifted behind the released version — meaning every local `bun install` rewrote it and showed up as spurious dirt in `git status`.

Fix adds a `bun install --lockfile-only` step to the release workflow, before the release PR is opened, and commits the catch-up bump (`apps/wallet` `1.0.87` → `1.0.89`) so the lockfile matches the current release.

## Risk

Minimal:
- No runtime/application code touched — a workflow step and a lockfile version field.
- The lockfile change is a version-string correction for a `workspace:*` package; no dependency resolution changes.
- Merges cleanly into `main` with no conflicts.

## Pending changesets
None. No publishable package source changed.
