### PR TITLE
feat(wallet): name the install code "reward code" across surfaces

### DIFF
--- a/apps/wallet/app/module/onboarding/component/OnboardingStep/OnboardingStep.test.tsx
+++ b/apps/wallet/app/module/onboarding/component/OnboardingStep/OnboardingStep.test.tsx
@@ -89,7 +89,7 @@ describe.sequential("OnboardingStep", () => {
         expect(onLoginClick).toHaveBeenCalled();
     });
 
-    it("renders the recovery code button when handler provided", () => {
+    it("renders the reward code button when handler provided", () => {
         const onRecoveryCodeClick = vi.fn();
         render(
             <OnboardingStep
@@ -101,13 +101,13 @@ describe.sequential("OnboardingStep", () => {
         );
 
         const recovery = screen.getByRole("button", {
-            name: "onboarding.recoveryCode",
+            name: "onboarding.rewardCode",
         });
         fireEvent.click(recovery);
         expect(onRecoveryCodeClick).toHaveBeenCalled();
     });
 
-    it("does not render the recovery code button when no handler is provided", () => {
+    it("does not render the reward code button when no handler is provided", () => {
         render(
             <OnboardingStep
                 hero={hero}
@@ -118,7 +118,7 @@ describe.sequential("OnboardingStep", () => {
 
         expect(
             screen.queryByRole("button", {
-                name: "onboarding.recoveryCode",
+                name: "onboarding.rewardCode",
             })
         ).not.toBeInTheDocument();
     });

--- a/apps/wallet/app/module/onboarding/component/OnboardingStep/index.tsx
+++ b/apps/wallet/app/module/onboarding/component/OnboardingStep/index.tsx
@@ -26,7 +26,7 @@ type OnboardingStepProps = {
     isLoginLoading?: boolean;
     /** Login error surfaced above the actions (login-enabled step only) */
     loginError?: Error | null;
-    /** Called when the user clicks the recovery code link */
+    /** Called when the user clicks the reward code link */
     onRecoveryCodeClick?: () => void;
 };
 
@@ -70,7 +70,7 @@ export function OnboardingStep({
                             variant="ghost"
                             onClick={() => onRecoveryCodeClick()}
                         >
-                            {t("onboarding.recoveryCode")}
+                            {t("onboarding.rewardCode")}
                         </Button>
                     )}
                 </>

--- a/apps/wallet/app/module/recovery-code/component/RecoveryCodePage/index.test.tsx
+++ b/apps/wallet/app/module/recovery-code/component/RecoveryCodePage/index.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 function typeCode(code: string) {
-    fireEvent.change(screen.getByLabelText("recoveryCode.codeLabel"), {
+    fireEvent.change(screen.getByLabelText("rewardCode.codeLabel"), {
         target: { value: code },
     });
 }
@@ -54,11 +54,11 @@ describe("RecoveryCodePage", () => {
 
         render(<RecoveryCodePage />, { wrapper: queryWrapper.wrapper });
         typeCode("ABC123");
-        fireEvent.click(screen.getByText("recoveryCode.validate"));
+        fireEvent.click(screen.getByText("rewardCode.validate"));
 
         await waitFor(() => expect(mockResolvePost).toHaveBeenCalled());
         expect(openModal).not.toHaveBeenCalled();
-        await screen.findByText("recoveryCode.error.unresolved");
+        await screen.findByText("rewardCode.error.unresolved");
     });
 
     test("a resolved code opens the success modal", async ({
@@ -76,7 +76,7 @@ describe("RecoveryCodePage", () => {
 
         render(<RecoveryCodePage />, { wrapper: queryWrapper.wrapper });
         typeCode("ABC123");
-        fireEvent.click(screen.getByText("recoveryCode.validate"));
+        fireEvent.click(screen.getByText("rewardCode.validate"));
 
         await waitFor(() =>
             expect(openModal).toHaveBeenCalledWith(

--- a/apps/wallet/app/module/recovery-code/component/RecoveryCodePage/index.tsx
+++ b/apps/wallet/app/module/recovery-code/component/RecoveryCodePage/index.tsx
@@ -61,16 +61,16 @@ export function RecoveryCodePage() {
     }, [isComplete, isPending, code, resolveAsync, openModal, navigate]);
 
     const errorMessage = error
-        ? t("recoveryCode.error.invalid")
+        ? t("rewardCode.error.invalid")
         : unresolved
-          ? t("recoveryCode.error.unresolved")
+          ? t("rewardCode.error.unresolved")
           : undefined;
 
     return (
         <FlowStepScreen
             fixedViewport
-            title={t("recoveryCode.title")}
-            description={t("recoveryCode.description")}
+            title={t("rewardCode.title")}
+            description={t("rewardCode.description")}
             onBack={() => navigate({ to: "/register", replace: true })}
             footer={
                 <Button
@@ -78,7 +78,7 @@ export function RecoveryCodePage() {
                     disabled={!isComplete}
                     loading={isPending}
                 >
-                    {t("recoveryCode.validate")}
+                    {t("rewardCode.validate")}
                 </Button>
             }
         >
@@ -86,8 +86,8 @@ export function RecoveryCodePage() {
                 length={CODE_LENGTH}
                 mode="alphanumeric"
                 onChange={handleCodeChange}
-                label={t("recoveryCode.codeLabel")}
-                pasteLabel={t("recoveryCode.paste")}
+                label={t("rewardCode.codeLabel")}
+                pasteLabel={t("rewardCode.paste")}
                 error={errorMessage}
                 // Sole input on this screen, so focusing on arrival costs the
                 // user nothing and saves a tap. On iOS it also surfaces a code

--- a/apps/wallet/app/module/recovery-code/component/RecoveryCodeSuccessModal/index.tsx
+++ b/apps/wallet/app/module/recovery-code/component/RecoveryCodeSuccessModal/index.tsx
@@ -30,8 +30,8 @@ export function RecoveryCodeSuccessModal({
             onOpenChange={(open) => {
                 if (!open) onClose();
             }}
-            title={t("recoveryCode.success.title")}
-            description={t("recoveryCode.success.description")}
+            title={t("rewardCode.success.title")}
+            description={t("rewardCode.success.description")}
         >
             <Box
                 display={"flex"}
@@ -42,14 +42,14 @@ export function RecoveryCodeSuccessModal({
             >
                 <CircleCheckIcon className={styles.successIcon} />
                 <Text variant="heading2" weight="semiBold">
-                    {t("recoveryCode.success.title")}
+                    {t("rewardCode.success.title")}
                 </Text>
                 <Text variant="bodySmall" weight="medium" color="secondary">
-                    {t("recoveryCode.success.description")}
+                    {t("rewardCode.success.description")}
                 </Text>
                 {merchant && (
                     <Text variant="bodySmall" weight="semiBold">
-                        {t("recoveryCode.success.merchantInfo", {
+                        {t("rewardCode.success.merchantInfo", {
                             merchantName: merchant.name,
                         })}
                     </Text>

--- a/packages/wallet-shared/src/i18n/locales/en/translation.json
+++ b/packages/wallet-shared/src/i18n/locales/en/translation.json
@@ -777,16 +777,16 @@
         },
         "confirmAction": "Confirm with {{type}}"
     },
-    "recoveryCode": {
-        "title": "Recover your code",
-        "description": "Paste the code copied from wallet.frak.id to recover your earnings.",
+    "rewardCode": {
+        "title": "Enter your reward code",
+        "description": "Paste the reward code you copied from wallet.frak.id to claim your earnings.",
         "paste": "Paste the code",
         "validate": "Validate the code",
-        "codeLabel": "Recovery code",
+        "codeLabel": "Reward code",
         "error": {
-            "invalid": "Incorrect or expired code, check the code copied from wallet.frak.id",
-            "alreadyLinked": "This code has already been used.",
-            "unresolved": "This code isn't linked to a purchase yet. Try again in a few minutes.",
+            "invalid": "Incorrect or expired reward code, check the code copied from wallet.frak.id",
+            "alreadyLinked": "This reward code has already been used.",
+            "unresolved": "This reward code isn't linked to a purchase yet. Try again in a few minutes.",
             "generic": "Something went wrong, please try again."
         },
         "success": {
@@ -796,15 +796,15 @@
         }
     },
     "installCode": {
-        "title": "Don't lose your {{ estimatedReward }}!\nCopy this code",
+        "title": "Don't lose your {{ estimatedReward }}!\nCopy your reward code",
         "description": "Paste it when opening the app. It will let you claim your rewards once logged in.",
         "codelessTitle": "Don't lose your {{ estimatedReward }}!",
         "codelessDescription": "Download the app and log in to claim your rewards.",
         "copyCode": "Copy the code",
-        "codeCopied": "Code copied!",
-        "loading": "Generating your code...",
+        "codeCopied": "Reward code copied!",
+        "loading": "Generating your reward code...",
         "infoTitle": "Code valid for 3 days",
-        "infoDescription": "When opening the app, tap <1>\"I have a recovery code\"</1>.",
+        "infoDescription": "When opening the app, tap <1>\"I have a reward code\"</1>.",
         "download": "Download the app",
         "processing": "Setting up your wallet...",
         "processingDone": "Your wallet is ready",
@@ -822,7 +822,7 @@
         "continue": "Continue",
         "activateSecureSpace": "Activate my secure space",
         "alreadyHaveAccount": "Already have an account?",
-        "recoveryCode": "I have a recovery code",
+        "rewardCode": "I have a reward code",
         "steps": {
             "one": {
                 "title": "Earn money by recommending",

--- a/packages/wallet-shared/src/i18n/locales/fr/translation.json
+++ b/packages/wallet-shared/src/i18n/locales/fr/translation.json
@@ -777,16 +777,16 @@
         },
         "confirmAction": "Confirmer avec {{type}}"
     },
-    "recoveryCode": {
-        "title": "Récupération de ton code",
-        "description": "Colle le code copié depuis wallet.frak.id pour récupérer tes gains.",
+    "rewardCode": {
+        "title": "Saisis ton code de récompense",
+        "description": "Colle le code de récompense copié depuis wallet.frak.id pour récupérer tes gains.",
         "paste": "Coller le code",
         "validate": "Valider le code",
-        "codeLabel": "Code de récupération",
+        "codeLabel": "Code de récompense",
         "error": {
-            "invalid": "Code incorrect ou expiré, vérifie le code copié depuis wallet.frak.id",
-            "alreadyLinked": "Ce code a déjà été utilisé.",
-            "unresolved": "Ce code n'est pas encore lié à un achat. Réessaie dans quelques minutes.",
+            "invalid": "Code de récompense incorrect ou expiré, vérifie le code copié depuis wallet.frak.id",
+            "alreadyLinked": "Ce code de récompense a déjà été utilisé.",
+            "unresolved": "Ce code de récompense n'est pas encore lié à un achat. Réessaie dans quelques minutes.",
             "generic": "Une erreur est survenue, réessaie."
         },
         "success": {
@@ -796,15 +796,15 @@
         }
     },
     "installCode": {
-        "title": "Ne perds pas tes {{ estimatedReward }} !\nCopie ce code",
+        "title": "Ne perds pas tes {{ estimatedReward }} !\nCopie ton code de récompense",
         "description": "Colle-le à l'ouverture de l'app. Il te permettra de récupérer tes gains une fois connecté·e.",
         "codelessTitle": "Ne perds pas tes {{ estimatedReward }} !",
         "codelessDescription": "Télécharge l'app et connecte-toi pour récupérer tes gains.",
         "copyCode": "Copier le code",
-        "codeCopied": "Code copié !",
-        "loading": "Génération de ton code...",
+        "codeCopied": "Code de récompense copié !",
+        "loading": "Génération de ton code de récompense...",
         "infoTitle": "Code valable 3 jours",
-        "infoDescription": "À l'ouverture de l'app, appuie sur <1>\"J'ai un code de récupération\"</1>.",
+        "infoDescription": "À l'ouverture de l'app, appuie sur <1>\"J'ai un code de récompense\"</1>.",
         "download": "Télécharger l'app",
         "processing": "Configuration de ton porte-monnaie...",
         "processingDone": "Ton porte-monnaie est prêt",
@@ -822,7 +822,7 @@
         "continue": "Continuer",
         "activateSecureSpace": "Activer mon espace sécurisé",
         "alreadyHaveAccount": "Déjà un compte ?",
-        "recoveryCode": "J'ai un code de récupération",
+        "rewardCode": "J'ai un code de récompense",
         "steps": {
             "one": {
                 "title": "Gagne de l'argent en recommandant",

--- a/packages/wallet-shared/src/i18n/locales/rewardCode.test.ts
+++ b/packages/wallet-shared/src/i18n/locales/rewardCode.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import en from "./en/translation.json";
+import fr from "./fr/translation.json";
+
+// Component tests assert on i18n keys — the setup loads no resources, so
+// i18next echoes the key back. Nothing there can see the words a user reads.
+const locales = { en, fr } as const;
+
+// The field label is the code's canonical name, so these stay true through a
+// term change: rename the code and every side of each assertion moves together.
+describe.each(["en", "fr"] as const)("reward code naming (%s)", (lng) => {
+    const t = locales[lng];
+    const name = t.rewardCode.codeLabel.toLowerCase();
+
+    it("names the code in the install page headline", () => {
+        expect(t.installCode.title.toLowerCase()).toContain(name);
+    });
+
+    it("quotes the app's entry button verbatim in the install instruction", () => {
+        const quoted =
+            t.installCode.infoDescription.match(/<1>"(.+?)"<\/1>/)?.[1];
+        expect(quoted).toBe(t.onboarding.rewardCode);
+    });
+});

--- a/packages/wallet-shared/src/types/i18n/resources.d.ts
+++ b/packages/wallet-shared/src/types/i18n/resources.d.ts
@@ -509,23 +509,23 @@ export default interface Resources {
       }
     },
     "installCode": {
-      "codeCopied": "Code copied!",
+      "codeCopied": "Reward code copied!",
       "codelessDescription": "Download the app and log in to claim your rewards.",
       "codelessTitle": "Don't lose your {{estimatedReward}}!",
       "copyCode": "Copy the code",
       "description": "Paste it when opening the app. It will let you claim your rewards once logged in.",
       "download": "Download the app",
-      "infoDescription": "When opening the app, tap <1>\"I have a recovery code\"</1>.",
+      "infoDescription": "When opening the app, tap <1>\"I have a reward code\"</1>.",
       "infoTitle": "Code valid for 3 days",
       "installedCodeToggle": "Or enter this code manually",
       "installedHeadline": "You're all set. Open the app to claim {{estimatedReward}}.",
       "installedMerchant": "Connected to {{merchantName}}",
-      "loading": "Generating your code...",
+      "loading": "Generating your reward code...",
       "openWallet": "Open Frak & claim {{estimatedReward}}",
       "openWalletCta": "Open my wallet",
       "processing": "Setting up your wallet...",
       "processingDone": "Your wallet is ready",
-      "title": "Don't lose your {{estimatedReward}}!\nCopy this code"
+      "title": "Don't lose your {{estimatedReward}}!\nCopy your reward code"
     },
     "monerium": {
       "account": "Monerium Account",
@@ -707,7 +707,6 @@ export default interface Resources {
         "skip": "Later",
         "title": "Don't miss any reward!"
       },
-      "recoveryCode": "I have a recovery code",
       "referral": {
         "appliedToast": "Referral code applied",
         "description": "Got a creator code? Enter it here. Otherwise, you can skip this step.",
@@ -717,6 +716,7 @@ export default interface Resources {
         "submitCta": "Apply code",
         "title": "Add a referral code"
       },
+      "rewardCode": "I have a reward code",
       "start": "Get started",
       "steps": {
         "one": {
@@ -742,24 +742,6 @@ export default interface Resources {
     },
     "pendingActions": {
       "walletAlreadyLinked": "This referral link is already linked to another wallet."
-    },
-    "recoveryCode": {
-      "codeLabel": "Recovery code",
-      "description": "Paste the code copied from wallet.frak.id to recover your earnings.",
-      "error": {
-        "alreadyLinked": "This code has already been used.",
-        "generic": "Something went wrong, please try again.",
-        "invalid": "Incorrect or expired code, check the code copied from wallet.frak.id",
-        "unresolved": "This code isn't linked to a purchase yet. Try again in a few minutes."
-      },
-      "paste": "Paste the code",
-      "success": {
-        "description": "You'll receive a notification as soon as a friend purchases via your link.",
-        "merchantInfo": "Connected to {{merchantName}}",
-        "title": "Your referral link has been found!"
-      },
-      "title": "Recover your code",
-      "validate": "Validate the code"
     },
     "reward": {
       "detail": {
@@ -806,6 +788,24 @@ export default interface Resources {
         "referral": "Referral",
         "unknown": "Reward"
       }
+    },
+    "rewardCode": {
+      "codeLabel": "Reward code",
+      "description": "Paste the reward code you copied from wallet.frak.id to claim your earnings.",
+      "error": {
+        "alreadyLinked": "This reward code has already been used.",
+        "generic": "Something went wrong, please try again.",
+        "invalid": "Incorrect or expired reward code, check the code copied from wallet.frak.id",
+        "unresolved": "This reward code isn't linked to a purchase yet. Try again in a few minutes."
+      },
+      "paste": "Paste the code",
+      "success": {
+        "description": "You'll receive a notification as soon as a friend purchases via your link.",
+        "merchantInfo": "Connected to {{merchantName}}",
+        "title": "Your referral link has been found!"
+      },
+      "title": "Enter your reward code",
+      "validate": "Validate the code"
     },
     "version": {
       "hardUpdate": {


### PR DESCRIPTION
Closes FRA-293 (bullets 1 and 2). Bullet 3 split to FRA-316.

## The problem

A logged-out shopper buys on a merchant site, gets a 6-character code on the embedded install page, installs the wallet, and pastes it to recover their purchase attribution. Lose the code, lose the reward.

That code had **no name** on the page handing it over ("Copy the code") and a **different** name in the app ("I have a recovery code") — so the shopper had to infer that the unnamed thing they copied was the "recovery code" the app asked for.

"Recovery" was also already taken. The wallet has a real, unrelated account-recovery flow — recovery link, password, backup — rendering *"I have a recovery backup instead"* one screen away. One restores wallet *access*; the other restores *purchase attribution*.

## What changed

Both surfaces now say **"reward code" / "code de récompense"**, signed off by Virginie.

| Surface | Before | After |
|---|---|---|
| Install page H1 | "Copy this code" | "Copy your reward code" |
| Install page instruction | tap *"I have a recovery code"* | tap *"I have a reward code"* |
| App entry button | "I have a recovery code" | "I have a reward code" |
| Paste screen | "Recover your code" | "Enter your reward code" |
| App-side i18n keys | `recoveryCode.*` | `rewardCode.*` |

The keys moved too, not just the values — leaving them would have preserved the collision in the code for the next reader.

`installCode.*` keys keep their names: they match the backend route and both native SDKs, and `locales/*/standalone.ts` imports that group **by name** for the tree-shaken `/install` bundle. Renaming it would have broken that build.

Naming the code at every control put it on screen 4×, so the H1 carries it and adjacent controls stay generic. The confirmation toast keeps the full name — it's read in isolation.

## Two guard tests

`packages/wallet-shared/src/i18n/locales/rewardCode.test.ts` asserts on **resolved values**, not keys. Component tests here assert on key strings (the setup loads no resources, so i18next echoes the key back), which means a green suite is compatible with users reading the wrong words.

- The install headline contains the code's name — the H1 is a two-line string, so a re-flow that drops the line break would otherwise kill this silently.
- The instruction's quoted text equals the entry button verbatim — the page quotes the app's control, so the two can't drift.

Both derive the expected value from the locale file rather than hardcoding "reward code", so a future term change moves both sides together. Verified falsifiable by mutation: each fails on the regression it claims to catch.

## Verification

- `bun run test` — 607 files, 5930 tests green
- `bun run lint` + `format` + comment budget clean
- `bun run i18n:types` reproduces `resources.d.ts` with no diff (generated, not hand-edited)
- EN/FR moved together; standalone locale guard green, so the `/install` tree-shake is intact
- **Pre-existing on `dev`:** two type errors in `apps/wallet/tests/helpers/sdk.helper.ts` (removed `DisplayEmbeddedWalletParamsType` export). Error sets on `dev` and this branch are byte-identical — this PR introduces none.

## Follow-ups

- **FRA-316** — bullet 3 (header "Skip >") plus the first-open routing it presumes, filed as one issue. That routing doesn't exist: `/recovery-code` has a single entry point (`register.tsx:295`), so back always resolves and there's nothing ahead to skip. Shipping the affordance alone would be a dead control.
- **FRA-317** — rename the internal `recovery-code` identifiers (module, components, route, modal discriminant). Deliberately excluded here to keep a copy change off a structural refactor.
