### PR TITLE
fix(wallet): harden the Monerium store against a hostile localStorage

### DIFF
--- a/apps/wallet/app/module/monerium/store/moneriumStore.test.ts
+++ b/apps/wallet/app/module/monerium/store/moneriumStore.test.ts
@@ -4,13 +4,19 @@ import {
     expect,
     test,
 } from "../../../../tests/vitest-fixtures";
-import { isMoneriumConnected, moneriumStore } from "./moneriumStore";
+import {
+    isMoneriumConnected,
+    MONERIUM_STORE_NAME,
+    moneriumStore,
+    PENDING_AUTH_TTL_MS,
+} from "./moneriumStore";
+
+beforeEach(() => {
+    moneriumStore.getState().disconnect();
+    localStorage.clear();
+});
 
 describe("moneriumStore", () => {
-    beforeEach(() => {
-        moneriumStore.getState().disconnect();
-    });
-
     describe("initial state", () => {
         test("should have correct initial values", () => {
             const state = moneriumStore.getState();
@@ -51,7 +57,8 @@ describe("moneriumStore", () => {
     });
 
     describe("setPendingAuth / clearPendingAuth", () => {
-        test("should set verifier and state together", () => {
+        test("should set verifier, state, and createdAt together", () => {
+            const beforeTime = Date.now();
             moneriumStore
                 .getState()
                 .setPendingAuth("verifier-abc", "state-xyz");
@@ -59,9 +66,12 @@ describe("moneriumStore", () => {
             const state = moneriumStore.getState();
             expect(state.pendingCodeVerifier).toBe("verifier-abc");
             expect(state.pendingState).toBe("state-xyz");
+            expect(state.pendingAuthCreatedAt).toBeGreaterThanOrEqual(
+                beforeTime
+            );
         });
 
-        test("should clear both verifier and state", () => {
+        test("should clear verifier, state, and createdAt together", () => {
             moneriumStore
                 .getState()
                 .setPendingAuth("verifier-abc", "state-xyz");
@@ -70,6 +80,7 @@ describe("moneriumStore", () => {
             const state = moneriumStore.getState();
             expect(state.pendingCodeVerifier).toBeNull();
             expect(state.pendingState).toBeNull();
+            expect(state.pendingAuthCreatedAt).toBeNull();
         });
     });
 
@@ -94,6 +105,7 @@ describe("moneriumStore", () => {
             expect(state.tokenExpiry).toBeNull();
             expect(state.pendingCodeVerifier).toBeNull();
             expect(state.pendingState).toBeNull();
+            expect(state.pendingAuthCreatedAt).toBeNull();
         });
     });
 
@@ -118,5 +130,179 @@ describe("moneriumStore", () => {
 
             expect(isMoneriumConnected(moneriumStore.getState())).toBe(false);
         });
+    });
+});
+
+const disconnected = {
+    accessToken: null,
+    refreshToken: null,
+    tokenExpiry: null,
+    pendingCodeVerifier: null,
+    pendingState: null,
+    pendingAuthCreatedAt: null,
+    hasSeenSetupSuccess: false,
+};
+
+// Derived from `disconnected` so the persisted field list lives in one place.
+function persistedSlice() {
+    const state = moneriumStore.getState() as Record<string, unknown>;
+    return Object.fromEntries(
+        Object.keys(disconnected).map((key) => [key, state[key]])
+    );
+}
+
+async function rehydrate(payload: unknown) {
+    localStorage.setItem(MONERIUM_STORE_NAME, JSON.stringify(payload));
+    await moneriumStore.persist.rehydrate();
+}
+
+const malformed = [
+    ["undefined", undefined],
+    ["a non-object payload", "not-an-object"],
+    ["an object missing fields", { accessToken: "tok" }],
+    ["a wrongly typed field", { ...disconnected, tokenExpiry: "soon" }],
+    ["a numeric token", { ...disconnected, accessToken: 12345 }],
+] as const;
+
+describe("moneriumStore — hydration guard", () => {
+    describe.each([
+        ["version 1", 1],
+        ["version 0", 0],
+        ["no version key", undefined],
+    ])("with %s", (_, version) => {
+        test.each(malformed)(
+            "degrades to disconnected on %s, without throwing",
+            async (_, state) => {
+                moneriumStore
+                    .getState()
+                    .setTokens("live", "live-refresh", 3600);
+
+                await rehydrate({ state, version });
+
+                expect(persistedSlice()).toEqual(disconnected);
+            }
+        );
+
+        test.each([
+            ["without a timestamp", undefined],
+            ["with its own timestamp", 1_700_000_000_000],
+        ])("carries a valid payload across %s", async (_, createdAt) => {
+            const valid = {
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+                tokenExpiry: 1234567890,
+                pendingCodeVerifier: null,
+                pendingState: null,
+                pendingAuthCreatedAt: createdAt,
+                hasSeenSetupSuccess: true,
+            };
+
+            await rehydrate({ state: valid, version });
+
+            expect(persistedSlice()).toEqual({
+                ...valid,
+                pendingAuthCreatedAt: createdAt ?? null,
+            });
+        });
+    });
+
+    test("drops unknown keys instead of overwriting actions", async () => {
+        await rehydrate({
+            state: { ...disconnected, disconnect: null, extra: "x" },
+            version: 1,
+        });
+
+        expect(persistedSlice()).toEqual(disconnected);
+        expect(() => moneriumStore.getState().disconnect()).not.toThrow();
+        expect("extra" in moneriumStore.getState()).toBe(false);
+    });
+});
+
+describe("moneriumStore — rehydration TTL", () => {
+    test("clears an expired pending pair but keeps tokens intact", async () => {
+        await rehydrate({
+            state: {
+                ...disconnected,
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+                tokenExpiry: Date.now() + 60_000,
+                pendingCodeVerifier: "stale-verifier",
+                pendingState: "stale-state",
+                pendingAuthCreatedAt: Date.now() - (PENDING_AUTH_TTL_MS + 1000),
+            },
+            version: 1,
+        });
+
+        const state = moneriumStore.getState();
+        expect(state.pendingCodeVerifier).toBeNull();
+        expect(state.pendingState).toBeNull();
+        expect(state.pendingAuthCreatedAt).toBeNull();
+        expect(state.accessToken).toBe("access-token");
+        expect(state.refreshToken).toBe("refresh-token");
+    });
+
+    test("clears a pending pair written before the timestamp existed", async () => {
+        await rehydrate({
+            state: {
+                ...disconnected,
+                pendingCodeVerifier: "legacy-verifier",
+                pendingState: "legacy-state",
+            },
+            version: 0,
+        });
+
+        expect(moneriumStore.getState().pendingCodeVerifier).toBeNull();
+    });
+
+    test("clears a pending pair stamped in the future", async () => {
+        await rehydrate({
+            state: {
+                ...disconnected,
+                pendingCodeVerifier: "future-verifier",
+                pendingState: "future-state",
+                pendingAuthCreatedAt: Date.now() + 10 * PENDING_AUTH_TTL_MS,
+            },
+            version: 1,
+        });
+
+        expect(moneriumStore.getState().pendingCodeVerifier).toBeNull();
+    });
+
+    test("keeps a fresh pending pair intact", async () => {
+        const freshCreatedAt = Date.now() - 1000;
+        await rehydrate({
+            state: {
+                ...disconnected,
+                pendingCodeVerifier: "fresh-verifier",
+                pendingState: "fresh-state",
+                pendingAuthCreatedAt: freshCreatedAt,
+            },
+            version: 1,
+        });
+
+        const state = moneriumStore.getState();
+        expect(state.pendingCodeVerifier).toBe("fresh-verifier");
+        expect(state.pendingState).toBe("fresh-state");
+        expect(state.pendingAuthCreatedAt).toBe(freshCreatedAt);
+    });
+});
+
+describe("moneriumStore — partialize", () => {
+    test("persists exactly the listed fields", () => {
+        moneriumStore
+            .getState()
+            .setTokens("access-token", "refresh-token", 3600);
+
+        const raw = localStorage.getItem(MONERIUM_STORE_NAME);
+        expect(raw).not.toBeNull();
+        const parsed = JSON.parse(raw as string) as {
+            state: Record<string, unknown>;
+            version: number;
+        };
+
+        expect(parsed.version).toBe(1);
+        expect(Object.keys(parsed.state).sort()).toEqual(
+            Object.keys(disconnected).sort()
+        );
     });
 });

--- a/apps/wallet/app/module/monerium/store/moneriumStore.ts
+++ b/apps/wallet/app/module/monerium/store/moneriumStore.ts
@@ -1,5 +1,14 @@
+import { recordError } from "@frak-labs/wallet-shared";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+
+export const MONERIUM_STORE_NAME = "frak_monerium_store";
+
+/**
+ * Window for the OAuth redirect to return. Wide enough for bank 2FA in an
+ * external browser on Tauri; a pair older than this is treated as abandoned.
+ */
+export const PENDING_AUTH_TTL_MS = 30 * 60 * 1000;
 
 type MoneriumStoreState = {
     accessToken: string | null;
@@ -12,6 +21,8 @@ type MoneriumStoreState = {
      */
     pendingCodeVerifier: string | null;
     pendingState: string | null;
+    /** Set together with the pending pair; drives the TTL on rehydration. */
+    pendingAuthCreatedAt: number | null;
     hasSeenSetupSuccess: boolean;
 
     setTokens: (access: string, refresh: string, expiresIn: number) => void;
@@ -21,15 +32,78 @@ type MoneriumStoreState = {
     disconnect: () => void;
 };
 
+type PersistedMoneriumState = Pick<
+    MoneriumStoreState,
+    | "accessToken"
+    | "refreshToken"
+    | "tokenExpiry"
+    | "pendingCodeVerifier"
+    | "pendingState"
+    | "pendingAuthCreatedAt"
+    | "hasSeenSetupSuccess"
+>;
+
+const initialPersistedState: PersistedMoneriumState = {
+    accessToken: null,
+    refreshToken: null,
+    tokenExpiry: null,
+    pendingCodeVerifier: null,
+    pendingState: null,
+    pendingAuthCreatedAt: null,
+    hasSeenSetupSuccess: false,
+};
+
+/**
+ * Picks the persisted slice out of whatever localStorage held. Runs on
+ * every hydration, so a payload anyone can write never reaches the store:
+ * a wrong type on any field yields the disconnected slice, and unknown
+ * keys are dropped rather than spread over the actions.
+ */
+function pickPersistedState(value: unknown): PersistedMoneriumState {
+    if (typeof value !== "object" || value === null) {
+        return initialPersistedState;
+    }
+    const state = value as Record<string, unknown>;
+    // `undefined` is accepted here alone: a v0 payload predates the field.
+    const pendingAuthCreatedAt = state.pendingAuthCreatedAt ?? null;
+    const isValid =
+        (state.accessToken === null || typeof state.accessToken === "string") &&
+        (state.refreshToken === null ||
+            typeof state.refreshToken === "string") &&
+        (state.tokenExpiry === null || typeof state.tokenExpiry === "number") &&
+        (state.pendingCodeVerifier === null ||
+            typeof state.pendingCodeVerifier === "string") &&
+        (state.pendingState === null ||
+            typeof state.pendingState === "string") &&
+        (pendingAuthCreatedAt === null ||
+            typeof pendingAuthCreatedAt === "number") &&
+        typeof state.hasSeenSetupSuccess === "boolean";
+    if (!isValid) return initialPersistedState;
+    return {
+        accessToken: state.accessToken as string | null,
+        refreshToken: state.refreshToken as string | null,
+        tokenExpiry: state.tokenExpiry as number | null,
+        pendingCodeVerifier: state.pendingCodeVerifier as string | null,
+        pendingState: state.pendingState as string | null,
+        pendingAuthCreatedAt: pendingAuthCreatedAt as number | null,
+        hasSeenSetupSuccess: state.hasSeenSetupSuccess as boolean,
+    };
+}
+
+/** A stamp in the future is a clock that moved; treat it as expired too. */
+export function isPendingAuthExpired(
+    createdAt: number | null,
+    now = Date.now()
+): boolean {
+    if (createdAt === null) return true;
+    const age = now - createdAt;
+    return age < 0 || age > PENDING_AUTH_TTL_MS;
+}
+
 export const moneriumStore = create<MoneriumStoreState>()(
     persist(
         (set) => ({
-            accessToken: null,
-            refreshToken: null,
-            tokenExpiry: null,
-            pendingCodeVerifier: null,
-            pendingState: null,
-            hasSeenSetupSuccess: false,
+            ...initialPersistedState,
 
             setTokens: (access, refresh, expiresIn) =>
                 set({
@@ -41,22 +115,49 @@ export const moneriumStore = create<MoneriumStoreState>()(
                 set({
                     pendingCodeVerifier: verifier,
                     pendingState: state,
+                    pendingAuthCreatedAt: Date.now(),
                 }),
             clearPendingAuth: () =>
-                set({ pendingCodeVerifier: null, pendingState: null }),
-            markSetupSuccessSeen: () => set({ hasSeenSetupSuccess: true }),
-            disconnect: () =>
                 set({
-                    accessToken: null,
-                    refreshToken: null,
-                    tokenExpiry: null,
                     pendingCodeVerifier: null,
                     pendingState: null,
-                    hasSeenSetupSuccess: false,
+                    pendingAuthCreatedAt: null,
                 }),
+            markSetupSuccessSeen: () => set({ hasSeenSetupSuccess: true }),
+            disconnect: () => set(initialPersistedState),
         }),
         {
-            name: "frak_monerium_store",
+            name: MONERIUM_STORE_NAME,
+            version: 1,
+            // Reuses the hydration picker: one list of persisted fields,
+            // so what is written can never drift from what is accepted.
+            partialize: (state: MoneriumStoreState) =>
+                pickPersistedState(state),
+            // Without `migrate` a v0 payload is discarded, logging out every
+            // connected user on upgrade. `migrate` only runs when the stored
+            // version differs, so validation lives in `merge`, which runs on
+            // every hydration; v0 -> v1 is the `pendingAuthCreatedAt` default.
+            migrate: (persistedState) => persistedState,
+            merge: (persistedState, currentState) => ({
+                ...currentState,
+                ...pickPersistedState(persistedState),
+            }),
+            /**
+             * Drops a PKCE pair older than the TTL or without a timestamp;
+             * tokens are left alone so a connected user stays connected.
+             * A read failure leaves the disconnected slice: reconnecting
+             * through the normal flow is the only recovery there is.
+             */
+            onRehydrateStorage: () => (state, error) => {
+                if (error) {
+                    recordError(error, { source: "monerium_store_rehydrate" });
+                    return;
+                }
+                if (!state || state.pendingCodeVerifier === null) return;
+                if (isPendingAuthExpired(state.pendingAuthCreatedAt)) {
+                    state.clearPendingAuth();
+                }
+            },
         }
     )
 );

--- a/apps/wallet/app/routes/_wallet/_protected/monerium.callback.test.tsx
+++ b/apps/wallet/app/routes/_wallet/_protected/monerium.callback.test.tsx
@@ -1,0 +1,186 @@
+/** @jsxImportSource react */
+
+import type * as WalletShared from "@frak-labs/wallet-shared";
+import type * as ReactRouter from "@tanstack/react-router";
+import { render, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+// `vi` must come from "vitest" directly: `vi.mock` is hoisted above module
+// imports, so routing it through the fixtures module would reference an
+// uninitialized binding.
+import { vi } from "vitest";
+import {
+    moneriumStore,
+    PENDING_AUTH_TTL_MS,
+} from "@/module/monerium/store/moneriumStore";
+import { beforeEach, describe, expect, test } from "@/tests/vitest-fixtures";
+
+type Search = { code?: string; state?: string; error?: string };
+
+const { mockSearch, mockExchange, mockTrackEvent } = vi.hoisted(() => ({
+    mockSearch: { current: {} as Search },
+    mockExchange: vi.fn(),
+    mockTrackEvent: vi.fn(),
+}));
+
+// `Route.useSearch()` reads the router context, which no bare `render` has.
+// Mocking the factory keeps `Route.options.component` reachable without
+// standing up a `RouterProvider`.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof ReactRouter>();
+    return {
+        ...actual,
+        useNavigate: () => vi.fn(),
+        createFileRoute: () => (options: Record<string, unknown>) => ({
+            options,
+            useSearch: () => mockSearch.current,
+        }),
+    };
+});
+
+vi.mock("@/module/monerium/utils/moneriumApi", () => ({
+    exchangeCodeForTokens: mockExchange,
+}));
+
+vi.mock("@frak-labs/wallet-shared", async (importOriginal) => {
+    const actual = await importOriginal<typeof WalletShared>();
+    return { ...actual, trackEvent: mockTrackEvent, recordError: vi.fn() };
+});
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { Route } from "./monerium.callback";
+
+const MoneriumCallback = Route.options.component as () => ReactElement;
+
+const VERIFIER = "verifier-abc";
+const STATE = "state-xyz";
+
+function outcomes(): string[] {
+    return mockTrackEvent.mock.calls
+        .filter(([name]) => name === "monerium_callback_outcome")
+        .map(([, payload]) => (payload as { outcome: string }).outcome);
+}
+
+describe("MoneriumCallback — pending auth guard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        moneriumStore.getState().disconnect();
+        mockSearch.current = {};
+        mockExchange.mockResolvedValue({
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+            expires_in: 3600,
+        });
+    });
+
+    test("exchanges the code when the pending pair is fresh", async ({
+        queryWrapper,
+    }) => {
+        moneriumStore.getState().setPendingAuth(VERIFIER, STATE);
+        mockSearch.current = { code: "auth-code", state: STATE };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() =>
+            expect(mockExchange).toHaveBeenCalledWith("auth-code", VERIFIER)
+        );
+        await waitFor(() => expect(outcomes()).toContain("exchanged"));
+        expect(moneriumStore.getState().accessToken).toBe("access-token");
+    });
+
+    test("refuses to exchange a pair older than the TTL", async ({
+        queryWrapper,
+    }) => {
+        moneriumStore.getState().setPendingAuth(VERIFIER, STATE);
+        moneriumStore.setState({
+            pendingAuthCreatedAt: Date.now() - (PENDING_AUTH_TTL_MS + 1000),
+        });
+        mockSearch.current = { code: "auth-code", state: STATE };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() => expect(outcomes()).toContain("session_expired"));
+        expect(mockExchange).not.toHaveBeenCalled();
+    });
+
+    test("refuses to exchange a pair stamped in the future", async ({
+        queryWrapper,
+    }) => {
+        moneriumStore.getState().setPendingAuth(VERIFIER, STATE);
+        moneriumStore.setState({
+            pendingAuthCreatedAt: Date.now() + 10 * PENDING_AUTH_TTL_MS,
+        });
+        mockSearch.current = { code: "auth-code", state: STATE };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() => expect(outcomes()).toContain("session_expired"));
+        expect(mockExchange).not.toHaveBeenCalled();
+    });
+
+    test("reports session_expired when no pending pair is stored", async ({
+        queryWrapper,
+    }) => {
+        mockSearch.current = { code: "auth-code", state: STATE };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() => expect(outcomes()).toContain("session_expired"));
+        expect(mockExchange).not.toHaveBeenCalled();
+    });
+
+    test("a state mismatch keeps the pending pair for a later callback", async ({
+        queryWrapper,
+    }) => {
+        moneriumStore.getState().setPendingAuth(VERIFIER, STATE);
+        mockSearch.current = { code: "auth-code", state: "not-ours" };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() => expect(outcomes()).toContain("csrf_mismatch"));
+        expect(mockExchange).not.toHaveBeenCalled();
+        expect(moneriumStore.getState().pendingCodeVerifier).toBe(VERIFIER);
+    });
+
+    test("an expired pair is refused before the CSRF check", async ({
+        queryWrapper,
+    }) => {
+        moneriumStore.getState().setPendingAuth(VERIFIER, STATE);
+        moneriumStore.setState({
+            pendingAuthCreatedAt: Date.now() - (PENDING_AUTH_TTL_MS + 1000),
+        });
+        mockSearch.current = { code: "auth-code", state: "not-ours" };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() => expect(outcomes()).toContain("session_expired"));
+        expect(outcomes()).not.toContain("csrf_mismatch");
+    });
+
+    test("clears the pending pair once the exchange succeeds", async ({
+        queryWrapper,
+    }) => {
+        moneriumStore.getState().setPendingAuth(VERIFIER, STATE);
+        mockSearch.current = { code: "auth-code", state: STATE };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() =>
+            expect(moneriumStore.getState().pendingCodeVerifier).toBeNull()
+        );
+        expect(moneriumStore.getState().pendingAuthCreatedAt).toBeNull();
+    });
+
+    test("records cancelled when the provider returns an error and no code", async ({
+        queryWrapper,
+    }) => {
+        mockSearch.current = { error: "access_denied" };
+
+        render(<MoneriumCallback />, { wrapper: queryWrapper.wrapper });
+
+        await waitFor(() => expect(outcomes()).toContain("cancelled"));
+        expect(mockExchange).not.toHaveBeenCalled();
+    });
+});

--- a/apps/wallet/app/routes/_wallet/_protected/monerium.callback.tsx
+++ b/apps/wallet/app/routes/_wallet/_protected/monerium.callback.tsx
@@ -10,7 +10,10 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DetailOverlay } from "@/module/common/component/DetailOverlay";
 import { MoneriumScreen } from "@/module/monerium/component/MoneriumBankFlow/MoneriumScreen";
-import { moneriumStore } from "@/module/monerium/store/moneriumStore";
+import {
+    isPendingAuthExpired,
+    moneriumStore,
+} from "@/module/monerium/store/moneriumStore";
 import { exchangeCodeForTokens } from "@/module/monerium/utils/moneriumApi";
 import { modalStore } from "@/module/stores/modalStore";
 import * as styles from "./monerium.callback.css";
@@ -85,6 +88,13 @@ function MoneriumCallback() {
     const [sessionExpired, setSessionExpired] = useState(false);
     const pendingCodeVerifier = moneriumStore((s) => s.pendingCodeVerifier);
     const pendingState = moneriumStore((s) => s.pendingState);
+    const pendingAuthCreatedAt = moneriumStore((s) => s.pendingAuthCreatedAt);
+    // The TTL is enforced here as well as on rehydration: a tab that was
+    // never reloaded still holds a pair from an abandoned redirect.
+    const hasUsablePendingAuth =
+        Boolean(pendingCodeVerifier) &&
+        Boolean(pendingState) &&
+        !isPendingAuthExpired(pendingAuthCreatedAt);
 
     const { mutate, isPending, isError, isSuccess } = useMutation({
         mutationFn: async ({
@@ -133,10 +143,10 @@ function MoneriumCallback() {
             });
             return;
         }
-        if (!pendingCodeVerifier || !pendingState) {
-            // Code present but our PKCE verifier is gone (already consumed,
-            // or store cleared between redirect and callback). Surface as a
-            // recoverable error rather than the generic CSRF screen.
+        if (!hasUsablePendingAuth || !pendingCodeVerifier) {
+            // Code present but our PKCE verifier is gone or stale (already
+            // consumed, cleared, or the redirect took too long). Surface as
+            // a recoverable error rather than the generic CSRF screen.
             if (sessionExpired) return;
             setSessionExpired(true);
             trackEvent("monerium_callback_outcome", {
@@ -171,6 +181,7 @@ function MoneriumCallback() {
         state,
         pendingCodeVerifier,
         pendingState,
+        pendingAuthCreatedAt,
         mutate,
         sessionExpired,
         error,
@@ -186,10 +197,7 @@ function MoneriumCallback() {
         !sessionExpired &&
         (isPending ||
             isSuccess ||
-            (Boolean(code) &&
-                Boolean(pendingCodeVerifier) &&
-                Boolean(pendingState) &&
-                !isError));
+            (Boolean(code) && hasUsablePendingAuth && !isError));
 
     return (
         <DetailOverlay

--- a/docs/audits/2026-08-05-frontend-findings-ranked-by-gain.md
+++ b/docs/audits/2026-08-05-frontend-findings-ranked-by-gain.md
@@ -167,7 +167,7 @@ The listener's three-ring architecture means "P1" is **not** uniform. Traced fro
 
 | # | Finding | Gain | Effort |
 |---|---|---|---|
-| **1** | **OAuth refresh token in plaintext localStorage** | `moneriumStore.ts:24-61` — no `partialize`, no `version`, no `migrate`; PKCE verifier/state persist indefinitely. Currently prod-gated — **fix before lifting the gate**. Sibling stores get this right | **S** |
+| ~~**1**~~ | ~~**OAuth refresh token in plaintext localStorage**~~ | **Fixed — shape hardened, storage kept.** `moneriumStore` now has `version: 1`, a `partialize` naming the seven persisted fields, and a guard in **`merge`** — not `migrate`, which zustand only calls when the stored version differs, so a guard there fires once per user on the v0→v1 upgrade and never again; anyone who can write localStorage writes `version: 1` and walks past it. `merge` runs on every hydration: a wrong type on any field yields the disconnected slice, and the slice is picked field by field, so an unknown key such as `disconnect: null` can no longer overwrite an action. The PKCE pair carries `pendingAuthCreatedAt` and is dropped after 30 min both on rehydration and at exchange time in the callback (a tab never reloaded would otherwise exchange a stale verifier); tokens are untouched, so a connected user stays connected. Rehydration errors reach `recordError`. Mutation-verified at v1 and v0: admitting every payload fails 9 tests, spreading the raw payload fails 20, dropping `migrate` (logs out every v0 user) fails 1, wiping tokens on TTL fails 1. **Still localStorage by decision**: a session-scoped refresh token would force an OAuth round trip on every launch of the bank flow; revisit if Monerium offers a shorter-lived grant | — |
 | **2** | **Explorer lookup: uncapped serial scan** | No page cap, 100/page, serial, against a 30-req/min backend limit → 429s past page 30. Compounds with #1: the moment a push points at `/explorer/{id}`, it lands on a cold start *and* runs this | **M** |
 | ~~**3**~~ | ~~**One error boundary for the whole app**~~ | **Fixed.** One shared boundary inside `AppShell` covers the four shell layouts, so a throw degrades the content region while the banner stack and tab bar survive; `_wallet` takes a route-level fallback since it renders no `AppShell`; `ModalOutlet`'s `Suspense` closes the modal and raises a toast. Both audit failure modes were reproduced live against a running wallet — a blocked chunk and an induced render throw — and neither blanks the app. Covered by 19 tests across 4 files, mutation-verified. Three corrections came out of the work: there are **4** layout routes, not 3 (`_sso` was missed, and it hosts a merchant-initiated flow); `errorComponent` is the wrong instrument on 4 of the 5, because `CatchBoundary` wraps the route's own `component` (`Match.js:84-90`) and would replace that layout's chrome; and the boundary must key on the pathname, not a constant — `AppShell` outlives sibling navigation, so a constant key stranded the user on the fallback with a working tab bar that changed nothing. Containment is render-phase only: a `beforeLoad` throw still reaches the root fallback, which is correct. Plan: `docs/plans/2026-09-08-1055-fix-wallet-error-boundaries-plan.md` | — |
 | ~~**4**~~ | ~~**`GlassButton` erases focus repo-wide**~~ | **Fixed.** Always-on 2px transparent outline (no layout shift), `vars.border.focus` on `:focus-visible` — and on `:focus-visible > &`, since `Back` nests the span variant inside a focusable `<Link>`. Covered by `tests-light/specs/glass-button.check.ts` (idle, pointer press, keyboard on both variants, one pixel snapshot); mutation-verified against the old CSS | — |
@@ -207,7 +207,7 @@ Everything here is real but absorbs cost the other two tiers cannot. **Two excep
 | **Chunk config triplicated (428 LOC)** | wallet, business, listener | P2/P3 | Listener's is the one with a hard-fail budget, so drift there is caught. `react-vendor` is byte-identical wallet↔business — start there |
 | **`zIndex` token bypassed (51 literals / 36 files)** | all | P1 (embedded wallet) → P2 | The 4 live collisions span tiers; the token itself is correct |
 | **`prefers-reduced-motion` unguarded** | DS keyframes + 11 files | P1 (sdk Banner keyframes, listener Spinner) | Two **infinite** animations (Skeleton pulse, Spinner spin). `MotionConfig`/`useReducedMotion` = 0 matches repo-wide |
-| **CI runs no quality job** | all | **P1** | 7 workflows, only the listener bundle budget. The 4-command gate at `AGENTS.md:16` is human-enforced and has measurably leaked |
+| ~~**CI runs no quality job**~~ | all | — | **Fixed** (`ff64ca82a`). The gate runs per area on pull requests — `biome ci` + unit tests for SDK, backend, wallet, business, listener+shopify, packages and infra, a `gates` job for the four `check:*` scripts, and workspace-wide `typecheck` — each behind the `changes` filter. Every vitest project is named exactly once |
 
 ---
 
@@ -232,7 +232,7 @@ Landed as one piece of work: credential-bearing lifecycle sends now carry the re
 ### Next — P2 smoothness + the P1 latency item (days)
 
 6. Add `modulepreload` for `cdn/loader.js` in the merchant plugins (P1 — see the note below; the shim itself must stay)
-7. `moneriumStore` hardening, before the prod gate lifts
+7. ~~`moneriumStore` hardening~~ — **done.** See §6.2 #1
 8. ~~Wallet error containment~~ — **done.** One shared boundary inside `AppShell`, `errorComponent` on `_wallet`, and a boundary around `ModalOutlet`'s `Suspense`. See §6.2 #3
 9. Retire the bespoke `DetailOverlay` portal in favour of the DS `Dialog` (it now has dialog semantics, but still no focus trap — see the resolved-log caveat)
 10. ~~Safe-area insets~~ — **done.** All nine `.css.ts` sites now import the `safeArea` token, gated by `bun run check:safe-area` inside `bun run lint`. See §6.2 #6
@@ -257,7 +257,7 @@ Landed as one piece of work: credential-bearing lifecycle sends now carry the re
 
 ### Add the enforcement the repo already knows how to write
 
-Every P1 finding above survived because **no gate covers that boundary**. The repo demonstrably knows the reflex — `assertComponentRegistrations`, the 32 KB hard-fail budget, the prod-build `BACKEND_URL` guard. Two of the three gaps are now closed: `check:publishable` (catches P1-5) and the executing `packages/rpc` tests (catch P1-1/2/3). Still missing: *any* CI job running the four-command gate.
+Every P1 finding above survived because **no gate covers that boundary**. The repo demonstrably knows the reflex — `assertComponentRegistrations`, the 32 KB hard-fail budget, the prod-build `BACKEND_URL` guard. All three gaps are now closed: `check:publishable` (catches P1-5), the executing `packages/rpc` tests (catch P1-1/2/3), and the per-area CI gate (`ff64ca82a`).
 
 ---
 

--- a/packages/wallet-shared/src/common/analytics/events/diagnostics.ts
+++ b/packages/wallet-shared/src/common/analytics/events/diagnostics.ts
@@ -19,6 +19,7 @@ export type AppErrorSource =
     | "tokens_send"
     | "monerium_callback"
     | "monerium_api"
+    | "monerium_store_rehydrate"
     | "recovery"
     | "sso"
     | "notifications"


### PR DESCRIPTION
## What

Closes the first P2 finding in `docs/audits/2026-08-05-frontend-findings-ranked-by-gain.md` (§6.2, "OAuth refresh token in plaintext localStorage") — the Monerium OAuth refresh token and PKCE pair sat under a bare `persist()` with no `partialize`, `version` or `migrate`, and a verifier from an abandoned redirect stayed in localStorage forever.

Three commits: the store fix, the audit tracker update (also strikes the "CI runs no quality job" row closed by `ff64ca82a`), and the callback's first tests.

## Change

**`moneriumStore.ts` — validation on every hydration.**

The guard runs in `merge`, not `migrate`. This is the correction that drove most of the review: zustand only calls `migrate` when the stored version *differs* from `options.version` (`middleware.js:394`). Every write carries `version: 1`, so a guard wired to `migrate` would run once per user on upgrade and never again — and a payload written by hand with `version: 1` would rehydrate verbatim. `merge` runs on every hydration, on every path, including a payload with no `version` key at all.

- the persisted slice is **picked field by field**, so unknown keys can't overwrite the store's own actions (a payload carrying `disconnect: null` previously replaced the action, bricking the wallet unrecoverably)
- `partialize` reuses that same picker, so what is written can never drift from what is accepted back
- `migrate` stays as an identity function and **must not be deleted** — without it zustand discards a v0 payload and logs out every connected user on upgrade. It looks like a no-op; it is load-bearing, and removing it fails 2 tests
- `pendingAuthCreatedAt` is written with the PKCE pair and expires it after 30 min — wide enough for bank 2FA in an external browser on Tauri, where the OAuth redirect leaves the app entirely. A stamp in the *future* means the device clock moved backward, and expires too
- rehydration errors reach `recordError` (`monerium_store_rehydrate`). A read failure means the token is unreadable, so the disconnected slice is the only recovery that exists

**`monerium.callback.tsx` — the TTL is also enforced at exchange time.** Rehydration alone doesn't cover a tab that was never reloaded but still holds a pair from an abandoned redirect. One derived `hasUsablePendingAuth` feeds both the exchange guard and the spinner, which had drifted apart.

**Storage stays localStorage by decision.** `sessionStorage` or memory would force an OAuth round trip on every launch of the bank flow; revisit if Monerium offers a shorter-lived grant. The prod gate on the callback route is untouched.

Public contract unchanged — `setPendingAuth`, `clearPendingAuth`, `setTokens`, `disconnect`, `markSetupSuccessSeen` and every consumer (`useMoneriumAuth`, `moneriumApi`, `monerium.callback`, `MoneriumBankFlow`) compile and behave as before.

## Verification

Tests drive the real persist middleware — a JSON payload under `frak_monerium_store`, then `moneriumStore.persist.rehydrate()` — rather than calling `migrate` directly. The malformed matrix runs at **version 1, version 0 and no version key**, which is what the original single-version matrix missed.

`monerium.callback.tsx` had no test file at all; it now has 8 covering the exchange guard, the TTL at both layers, the CSRF branch that must *keep* the pending pair, and the post-exchange lifecycle.

Mutation-verified — each number is tests that go red when the behaviour is removed:

| Mutation | Red |
|---|---|
| guard admits every payload | 9 |
| `merge` spreads the raw payload | 21 |
| `migrate` removed | 2 |
| future-stamp check dropped | 1 |
| TTL wipes tokens instead of the pair | 1 |
| callback-side TTL removed | 3 |
| pending pair cleared on CSRF mismatch | 1 |

Gate on the pushed tip: `format` clean · `lint` 0 · `typecheck` 0 (wallet **and** `wallet-shared`, since `AppErrorSource` is a shared union) · 53/53 across the 4 Monerium suites.

## Deploying this

**Prod is unaffected** — the callback route hard-redirects on `isRunningInProd` and `moneriumConfig` points at the sandbox off-prod, so this ships dead code there. The audit's "fix before lifting the gate" is now satisfied.

**On dev, there is a one-time migration per user.** A well-formed store carries across (`version` rewritten 0→1, `pendingAuthCreatedAt` defaulted `null`) and the user stays connected. A malformed one resets to disconnected and needs a reconnect — intended, but irreversible per user, and the guard is all-or-nothing: one wrong field type discards the whole slice including good tokens. Anyone mid-OAuth across the deploy lands on `session_expired` and simply reconnects.

Worth one manual check that no test can perform: load dev with an existing Monerium connection and confirm you stay connected.

## Notes

- **No changeset needed.** `@frak-labs/nexus-wallet` is `private` and in the `ignore` list; `@frak-labs/wallet-shared` is `private` and has never appeared in changeset frontmatter. The bot warning is expected.
- **Follow-up, not in this PR:** `pendingActionsStore.ts` carries the same false "unversioned is treated as v0" comment and the same `migrate`-only validation. Lower severity — its `partialize` emits only `actions` and its `migrate` builds a fresh object rather than spreading, so actions can't be clobbered. The real gap there is `Array.isArray` with no per-element check.
